### PR TITLE
Make bipartite nodes compatible with learn2branch

### DIFF
--- a/libecole/src/observation/nodebipartite.cpp
+++ b/libecole/src/observation/nodebipartite.cpp
@@ -85,7 +85,9 @@ static auto extract_row_feat(scip::Model const& model) {
 
 	auto extract_row = [n_lps, obj_l2_norm](auto& iter, auto const row, bool const lhs) {
 		value_type const sign = lhs ? -1. : 1.;
-		value_type const row_l2_norm = static_cast<value_type>(row.l2_norm());
+		value_type row_l2_norm = static_cast<value_type>(row.l2_norm());
+		if (row_l2_norm == 0) row_l2_norm = 1.;
+
 		if (lhs) {
 			*(iter++) = sign * row.lhs().value() / row_l2_norm;
 			*(iter++) = static_cast<value_type>(row.is_at_lhs());

--- a/libecole/src/observation/nodebipartite.cpp
+++ b/libecole/src/observation/nodebipartite.cpp
@@ -87,10 +87,10 @@ static auto extract_row_feat(scip::Model const& model) {
 		value_type const sign = lhs ? -1. : 1.;
 		value_type const row_l2_norm = static_cast<value_type>(row.l2_norm());
 		if (lhs) {
-			*(iter++) = row.lhs().value() / row_l2_norm;
+			*(iter++) = sign * row.lhs().value() / row_l2_norm;
 			*(iter++) = static_cast<value_type>(row.is_at_lhs());
 		} else {
-			*(iter++) = row.rhs().value() / row_l2_norm;
+			*(iter++) = sign * row.rhs().value() / row_l2_norm;
 			*(iter++) = static_cast<value_type>(row.is_at_rhs());
 		}
 		*(iter++) = static_cast<value_type>(row.age()) / (n_lps + cste);

--- a/libecole/src/scip/row.cpp
+++ b/libecole/src/scip/row.cpp
@@ -33,8 +33,7 @@ int RowProxy::n_lp_nonz() const noexcept {
 }
 
 real RowProxy::l2_norm() const noexcept {
-	auto norm = SCIProwGetNorm(value);
-	return norm > 0 ? norm : 1.;
+	return SCIProwGetNorm(value);
 }
 
 real RowProxy::obj_cos_sim() const noexcept {

--- a/libecole/src/scip/row.cpp
+++ b/libecole/src/scip/row.cpp
@@ -34,7 +34,7 @@ int RowProxy::n_lp_nonz() const noexcept {
 
 real RowProxy::l2_norm() const noexcept {
 	auto norm = SCIProwGetNorm(value);
-    return norm > 0 ? norm : 1.;
+	return norm > 0 ? norm : 1.;
 }
 
 real RowProxy::obj_cos_sim() const noexcept {

--- a/libecole/src/scip/row.cpp
+++ b/libecole/src/scip/row.cpp
@@ -33,7 +33,8 @@ int RowProxy::n_lp_nonz() const noexcept {
 }
 
 real RowProxy::l2_norm() const noexcept {
-	return SCIProwGetNorm(value);
+	auto norm = SCIProwGetNorm(value);
+    return norm > 0 ? norm : 1.;
 }
 
 real RowProxy::obj_cos_sim() const noexcept {

--- a/libecole/src/scip/variable.cpp
+++ b/libecole/src/scip/variable.cpp
@@ -32,7 +32,7 @@ optional<real> VarProxy::best_sol_val() const noexcept {
 }
 
 optional<real> VarProxy::avg_sol() const noexcept {
-	if (SCIPgetBestSol(scip) == nullptr)
+	if (SCIPgetBestSol(scip) != nullptr)
 		return SCIPvarGetAvgSol(value);
 	else
 		return {};


### PR DESCRIPTION
I doublechecked if the bipartite node features in Ecole matched the old learn2branch node features. it wasn't the case, but after the following fixes I now get the same results.

```
> np.abs(new_col_feat - col_feat['values']).max()
2.9450719307710926e-08
> np.abs(new_row_feat - row_feat['values'][new_to_old, :]).max()
7.080813868576286e-08
```

Ideally, we would also add a unit test to make them match; however, this would require the developer to have a custom version of PySCIPOpt I think? I don't really need how to make this light.

In addition, this is my first pull request. Is there tools I need to run on my PR?