### PR TITLE
Node bipartite names and submodule imports

### DIFF
--- a/libecole/include/ecole/observation/nodebipartite.hpp
+++ b/libecole/include/ecole/observation/nodebipartite.hpp
@@ -16,9 +16,9 @@ class NodeBipartiteObs {
 public:
 	using value_type = double;
 
-	xt::xtensor<value_type, 2> col_feat;
-	xt::xtensor<value_type, 2> row_feat;
-	utility::coo_matrix<value_type> matrix;
+	xt::xtensor<value_type, 2> column_features;
+	xt::xtensor<value_type, 2> row_features;
+	utility::coo_matrix<value_type> edge_features;
 };
 
 class NodeBipartite : public ObservationFunction<nonstd::optional<NodeBipartiteObs>> {

--- a/libecole/src/observation/nodebipartite.cpp
+++ b/libecole/src/observation/nodebipartite.cpp
@@ -10,7 +10,7 @@
 namespace ecole {
 namespace observation {
 
-using tensor = decltype(NodeBipartiteObs::col_feat);
+using tensor = decltype(NodeBipartiteObs::column_features);
 using value_type = tensor::value_type;
 
 static value_type constexpr cste = 5.;
@@ -126,7 +126,7 @@ static auto matrix_nnz(scip::Model const& model) {
 	return nnz;
 }
 
-static utility::coo_matrix<value_type> matrix(scip::Model const& model) {
+static utility::coo_matrix<value_type> extract_edge_feat(scip::Model const& model) {
 	auto const scip = model.get_scip_ptr();
 
 	using coo_matrix = utility::coo_matrix<value_type>;
@@ -168,7 +168,9 @@ auto NodeBipartite::obtain_observation(environment::State const& state)
 	-> nonstd::optional<NodeBipartiteObs> {
 	if (state.model.get_stage() == SCIP_STAGE_SOLVING) {
 		return NodeBipartiteObs{
-			extract_col_feat(state.model), extract_row_feat(state.model), matrix(state.model)};
+			extract_col_feat(state.model),
+			extract_row_feat(state.model),
+			extract_edge_feat(state.model)};
 	} else {
 		return {};
 	}

--- a/python/src/ecole/__init__.py.in
+++ b/python/src/ecole/__init__.py.in
@@ -1,1 +1,7 @@
 __version__ = "@Ecole_VERSION@"  # Filled by CMake
+
+import ecole.environment
+import ecole.observation
+import ecole.reward
+import ecole.scip
+import ecole.termination

--- a/python/src/ecole/core/observation.cpp
+++ b/python/src/ecole/core/observation.cpp
@@ -52,7 +52,7 @@ void bind_submodule(py::module m) {
 	def_reset(nothing, R"(Do nothing.)");
 	def_obtain_observation(nothing, R"(Return None.)");
 
-	using coo_matrix = decltype(NodeBipartiteObs::matrix);
+	using coo_matrix = decltype(NodeBipartiteObs::edge_features);
 	py::class_<coo_matrix>(m, "coo_matrix", R"(
 		Sparse matrix in the coordinate format.
 		
@@ -87,18 +87,18 @@ void bind_submodule(py::module m) {
 		Each edge is associated with the coefficient of the variable in the constraint.
 	)")  //
 		.def_property_readonly(
-			"col_feat",
-			[](NodeBipartiteObs & self) -> auto& { return self.col_feat; },
+			"column_features",
+			[](NodeBipartiteObs & self) -> auto& { return self.column_features; },
 			"A matrix where each row is represents a variable, and each column a feature of "
 			"the variables.")
 		.def_property_readonly(
-			"row_feat",
-			[](NodeBipartiteObs & self) -> auto& { return self.row_feat; },
+			"row_features",
+			[](NodeBipartiteObs & self) -> auto& { return self.row_features; },
 			"A matrix where each row is represents a constraint, and each column a feature of "
 			"the constraints.")
 		.def_readwrite(
-			"matrix",
-			&NodeBipartiteObs::matrix,
+			"edge_features",
+			&NodeBipartiteObs::edge_features,
 			"The constraint matrix of the optimization problem, with rows for contraints and "
 			"columns for variables.");
 
@@ -106,7 +106,6 @@ void bind_submodule(py::module m) {
 		Bipartite graph observation function on branch-and bound node.
 
 		This observation function extract structured :py:class:`NodeBipartiteObs`.
-
 	)");
 	node_bipartite.def(py::init<>());
 	def_reset(

--- a/python/tests/test_observation.py
+++ b/python/tests/test_observation.py
@@ -51,19 +51,22 @@ def test_DictFunction(state):
 def test_NodeBipartite(solving_state):
     obs = O.NodeBipartite().obtain_observation(solving_state)
     assert isinstance(obs, O.NodeBipartiteObs)
-    assert isinstance(obs.col_feat, np.ndarray)
+    assert isinstance(obs.column_features, np.ndarray)
 
-    assert obs.col_feat.size > 0
-    assert len(obs.col_feat.shape) == 2
-    assert obs.row_feat.size > 0
-    assert len(obs.row_feat.shape) == 2
-    assert obs.matrix.shape == (obs.row_feat.shape[0], obs.col_feat.shape[0])
-    assert obs.matrix.indices.shape == (2, obs.matrix.nnz)
+    assert obs.column_features.size > 0
+    assert len(obs.column_features.shape) == 2
+    assert obs.row_features.size > 0
+    assert len(obs.row_features.shape) == 2
+    assert obs.edge_features.shape == (
+        obs.row_features.shape[0],
+        obs.column_features.shape[0],
+    )
+    assert obs.edge_features.indices.shape == (2, obs.edge_features.nnz)
 
     val = np.random.rand()
-    obs.col_feat[:] = val
-    assert np.all(obs.col_feat == val)
-    obs.row_feat[:] = val
-    assert np.all(obs.row_feat == val)
-    obs.matrix.values[:] = val
-    assert np.all(obs.matrix.values == val)
+    obs.column_features[:] = val
+    assert np.all(obs.column_features == val)
+    obs.row_features[:] = val
+    assert np.all(obs.row_features == val)
+    obs.edge_features.values[:] = val
+    assert np.all(obs.edge_features.values == val)


### PR DESCRIPTION
This pull request proposes to change names of the node bipartite observation features as:
- `obs.row_feat` -> `obs.row_features`
- `obs.col_feat` -> `obs.column_features`
- `obs.matrix` -> `obs.edge_features`


Also, right now we must manually import every submodule we wish to use:
```
import ecole.environment

env = ecole.environment.Branching()
```
This pull request proposes to bring back submodule imports, so that
```
import ecole

env = ecole.environment.Branching()
```
works again. (It used to be the case.)