### PR TITLE
Implementation and test of the new NNodes reward function

### DIFF
--- a/docs/reference/rewards.rst
+++ b/docs/reference/rewards.rst
@@ -23,6 +23,12 @@ LP Iterations
    :no-members:
    :members: reset, obtain_reward
 
+NNodes
+^^^^^^^^^^^^^
+.. autoclass:: ecole.reward.NNodes
+   :no-members:
+   :members: reset, obtain_reward
+
 
 Utilities
 ---------

--- a/libecole/CMakeLists.txt
+++ b/libecole/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(
 	src/utility/reverse-control.cpp
 	src/reward/isdone.cpp
 	src/reward/lpiterations.cpp
+	src/reward/nnodes.cpp
 	src/observation/nodebipartite.cpp
 	src/observation/strongbranchingscores.cpp
 	src/environment/branching-dynamics.cpp

--- a/libecole/include/ecole/reward/nnodes.hpp
+++ b/libecole/include/ecole/reward/nnodes.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "ecole/reward/abstract.hpp"
+#include "ecole/scip/type.hpp"
+
+namespace ecole {
+namespace reward {
+
+class NNodes : public RewardFunction {
+public:
+	void reset(scip::Model const& model) override;
+	Reward obtain_reward(scip::Model const& model, bool done = false) override;
+
+private:
+	scip::long_int last_n_nodes = 0;
+};
+
+}  // namespace reward
+}  // namespace ecole

--- a/libecole/src/reward/nnodes.cpp
+++ b/libecole/src/reward/nnodes.cpp
@@ -12,7 +12,7 @@ void NNodes::reset(scip::Model const&) {
 Reward NNodes::obtain_reward(scip::Model const& model, bool /* done */) {
 	auto n_nodes_diff = SCIPgetNTotalNodes(model.get_scip_ptr()) - last_n_nodes;
 	last_n_nodes += n_nodes_diff;
-	return static_cast<double>(-n_nodes_diff);
+	return static_cast<double>(n_nodes_diff);
 }
 
 }  // namespace reward

--- a/libecole/src/reward/nnodes.cpp
+++ b/libecole/src/reward/nnodes.cpp
@@ -1,0 +1,19 @@
+#include "ecole/reward/nnodes.hpp"
+
+#include "ecole/scip/model.hpp"
+
+namespace ecole {
+namespace reward {
+
+void NNodes::reset(scip::Model const&) {
+	last_n_nodes = 0;
+}
+
+Reward NNodes::obtain_reward(scip::Model const& model, bool /* done */) {
+	auto n_nodes_diff = SCIPgetNTotalNodes(model.get_scip_ptr()) - last_n_nodes;
+	last_n_nodes += n_nodes_diff;
+	return static_cast<double>(-n_nodes_diff);
+}
+
+}  // namespace reward
+}  // namespace ecole

--- a/libecole/tests/CMakeLists.txt
+++ b/libecole/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(
 	src/reward/test-isdone.cpp
 	src/observation/test-nothing.cpp
 	src/observation/test-nodebipartite.cpp
+	src/reward/test-nnodes.cpp
 	src/observation/test-strongbranchingscores.cpp
 )
 

--- a/libecole/tests/src/reward/test-nnodes.cpp
+++ b/libecole/tests/src/reward/test-nnodes.cpp
@@ -1,0 +1,55 @@
+#include <memory>
+#include <string>
+#include <tuple>
+
+#include <catch2/catch.hpp>
+
+#include "ecole/environment/branching.hpp"
+#include "ecole/observation/nothing.hpp"
+#include "ecole/reward/nnodes.hpp"
+
+#include "conftest.hpp"
+
+using namespace ecole;
+
+TEST_CASE("Using the NNodes reward in a Branching environment") {
+	auto env = environment::Branching<observation::Nothing, reward::NNodes>{
+		{},
+		{},
+		{
+			{"presolving/maxrounds", 0},  // just to save time here
+			{"limits/totalnodes", 20},
+		},
+		true};
+
+	decltype(env)::ActionSet action_set;
+	reward::Reward reward;
+	bool done;
+
+	for (auto i = 0; i < 2; ++i) {
+		std::tie(std::ignore, action_set, reward, done) = env.reset(problem_file);
+
+		auto cum_reward = reward;
+		int n_steps = 0;
+
+		// Assert that the reward is non-positive
+		REQUIRE(reward <= 0);
+		// Assert that the cumulated reward (negative total number of nodes) is smaller than the
+		// negative number of branching steps
+		REQUIRE(cum_reward <= n_steps);
+
+		while (!done) {
+			std::tie(std::ignore, action_set, reward, done, std::ignore) =
+				env.step(action_set.value()[0]);  // dumb action
+
+			cum_reward += reward;
+			n_steps += 1;
+
+			// Assert that the reward is non-positive
+			REQUIRE(reward <= 0);
+			// Assert that the cumulated reward (negative total number of nodes) is smaller than the
+			// negative number of branching steps
+			REQUIRE(cum_reward <= n_steps);
+		}
+	}
+}

--- a/libecole/tests/src/reward/test-nnodes.cpp
+++ b/libecole/tests/src/reward/test-nnodes.cpp
@@ -9,47 +9,77 @@
 #include "ecole/reward/nnodes.hpp"
 
 #include "conftest.hpp"
+#include "reward/unit-tests.hpp"
 
 using namespace ecole;
 
-TEST_CASE("Using the NNodes reward in a Branching environment") {
-	auto env = environment::Branching<observation::Nothing, reward::NNodes>{
-		{},
-		{},
-		{
-			{"presolving/maxrounds", 0},  // just to save time here
-			{"limits/totalnodes", 20},
-		},
-		true};
+TEST_CASE("NNodes unit tests", "[unit][reward]") {
+	reward::unit_tests(reward::NNodes{});
+}
 
-	decltype(env)::ActionSet action_set;
-	reward::Reward reward;
-	bool done;
+TEST_CASE(
+	"NNodes returns the difference in the total number of processed nodes between two states",
+	"[reward]") {
 
-	for (auto i = 0; i < 2; ++i) {
-		std::tie(std::ignore, action_set, reward, done) = env.reset(problem_file);
+	auto reward_func = reward::NNodes{};
+	auto model = get_solving_model();
+	reward_func.reset(model);
 
-		auto cum_reward = reward;
-		int n_steps = 0;
+	SECTION("NNodes is positive") { REQUIRE(reward_func.obtain_reward(model) >= 0); }
 
-		// Assert that the number of nodes is non-negative
-		REQUIRE(reward >= 0);
-		// Assert that the cumulated reward (total number of nodes) is greater than the number of
-		// branching steps
-		REQUIRE(cum_reward >= n_steps);
+	SECTION("NNodes is zero if nothing happended between two states") {
+		reward_func.obtain_reward(model);
+		REQUIRE(reward_func.obtain_reward(model) == 0);
+	}
 
-		while (!done) {
-			std::tie(std::ignore, action_set, reward, done, std::ignore) =
-				env.step(action_set.value()[0]);  // dumb action
+	SECTION("Reset NNodes counter") {
+		reward_func.reset(model);
+		REQUIRE(reward_func.obtain_reward(model) >= 0);
+	}
 
-			cum_reward += reward;
-			n_steps += 1;
+	SECTION("NNodes is consistent when used in a Branching environment") {
+		int max_nnodes = 20;
+		auto env = environment::Branching<observation::Nothing, reward::NNodes>{
+			{},
+			{},
+			{
+				{"presolving/maxrounds", 0},  // just to save time here
+				{"limits/totalnodes", max_nnodes},
+			},
+			true};
+
+		decltype(env)::ActionSet action_set;
+		reward::Reward reward;
+		bool done;
+
+		for (auto i = 0; i < 2; ++i) {
+			std::tie(std::ignore, action_set, reward, done) = env.reset(problem_file);
+
+			auto cum_reward = reward;
+			int n_steps = 0;
 
 			// Assert that the number of nodes is non-negative
 			REQUIRE(reward >= 0);
 			// Assert that the cumulated reward (total number of nodes) is greater than the number of
 			// branching steps
 			REQUIRE(cum_reward >= n_steps);
+
+			while (!done) {
+				std::tie(std::ignore, action_set, reward, done, std::ignore) =
+					env.step(action_set.value()[0]);  // dumb action
+
+				cum_reward += reward;
+				n_steps += 1;
+
+				// Assert that the number of nodes is non-negative
+				REQUIRE(reward >= 0);
+				// Assert that the cumulated reward (total number of nodes) is greater than the number of
+				// branching steps
+				REQUIRE(cum_reward >= n_steps);
+			}
+			// Assert that the cumulated reward (total number of nodes) is not higher than the masimum
+			// number of nodes authorized in the environment
+			REQUIRE(cum_reward <= max_nnodes);
 		}
 	}
 }

--- a/libecole/tests/src/reward/test-nnodes.cpp
+++ b/libecole/tests/src/reward/test-nnodes.cpp
@@ -32,11 +32,11 @@ TEST_CASE("Using the NNodes reward in a Branching environment") {
 		auto cum_reward = reward;
 		int n_steps = 0;
 
-		// Assert that the reward is non-positive
-		REQUIRE(reward <= 0);
-		// Assert that the cumulated reward (negative total number of nodes) is smaller than the
-		// negative number of branching steps
-		REQUIRE(cum_reward <= n_steps);
+		// Assert that the number of nodes is non-negative
+		REQUIRE(reward >= 0);
+		// Assert that the cumulated reward (total number of nodes) is greater than the number of
+		// branching steps
+		REQUIRE(cum_reward >= n_steps);
 
 		while (!done) {
 			std::tie(std::ignore, action_set, reward, done, std::ignore) =
@@ -45,11 +45,11 @@ TEST_CASE("Using the NNodes reward in a Branching environment") {
 			cum_reward += reward;
 			n_steps += 1;
 
-			// Assert that the reward is non-positive
-			REQUIRE(reward <= 0);
-			// Assert that the cumulated reward (negative total number of nodes) is smaller than the
-			// negative number of branching steps
-			REQUIRE(cum_reward <= n_steps);
+			// Assert that the number of nodes is non-negative
+			REQUIRE(reward >= 0);
+			// Assert that the cumulated reward (total number of nodes) is greater than the number of
+			// branching steps
+			REQUIRE(cum_reward >= n_steps);
 		}
 	}
 }

--- a/python/src/ecole/core/reward.cpp
+++ b/python/src/ecole/core/reward.cpp
@@ -4,6 +4,7 @@
 #include "ecole/reward/constant.hpp"
 #include "ecole/reward/isdone.hpp"
 #include "ecole/reward/lpiterations.hpp"
+#include "ecole/reward/nnodes.hpp"
 #include "ecole/scip/model.hpp"
 
 #include "core.hpp"
@@ -127,6 +128,20 @@ void bind_submodule(py::module m) {
 		Update the internal LP iteration count and return the difference.
 
 		The difference in LP iterations is computed in between calls.
+		)");
+
+	auto nnodes = py::class_<NNodes>(m, "NNodes", R"(
+		Number of nodes difference.
+
+		The reward is defined as the total number of nodes processed since the previous state.
+	)");
+	nnodes.def(py::init<>());
+	def_operators(nnodes);
+	def_reset(nnodes, "Resets the internal node count.");
+	def_obtain_reward(nnodes, R"(
+		Updates the internal node count and returns the difference.
+
+		The difference in number of nodes is computed in between calls.
 		)");
 }
 

--- a/python/src/ecole/core/reward.cpp
+++ b/python/src/ecole/core/reward.cpp
@@ -137,9 +137,9 @@ void bind_submodule(py::module m) {
 	)");
 	nnodes.def(py::init<>());
 	def_operators(nnodes);
-	def_reset(nnodes, "Resets the internal node count.");
+	def_reset(nnodes, "Reset the internal node count.");
 	def_obtain_reward(nnodes, R"(
-		Updates the internal node count and returns the difference.
+		Update the internal node count and return the difference.
 
 		The difference in number of nodes is computed in between calls.
 		)");

--- a/python/tests/test_reward.py
+++ b/python/tests/test_reward.py
@@ -101,4 +101,4 @@ def test_LpIterations(model):
 def test_NNodes(model):
     reward_func = R.NNodes()
     reward_func.reset(model)
-    assert reward_func.obtain_reward(model) <= 0
+    assert reward_func.obtain_reward(model) >= 0

--- a/python/tests/test_reward.py
+++ b/python/tests/test_reward.py
@@ -90,15 +90,3 @@ def test_cumsum(reward_function, model):
 
     assert cum_reward1 == reward1
     assert cum_reward2 == reward1 + reward2
-
-
-def test_LpIterations(model):
-    reward_func = R.LpIterations()
-    reward_func.reset(model)
-    assert reward_func.obtain_reward(model) <= 0
-
-
-def test_NNodes(model):
-    reward_func = R.NNodes()
-    reward_func.reset(model)
-    assert reward_func.obtain_reward(model) >= 0

--- a/python/tests/test_reward.py
+++ b/python/tests/test_reward.py
@@ -90,3 +90,15 @@ def test_cumsum(reward_function, model):
 
     assert cum_reward1 == reward1
     assert cum_reward2 == reward1 + reward2
+
+
+def test_LpIterations(model):
+    reward_func = R.LpIterations()
+    reward_func.reset(model)
+    assert reward_func.obtain_reward(model) <= 0
+
+
+def test_NNodes(model):
+    reward_func = R.NNodes()
+    reward_func.reset(model)
+    assert reward_func.obtain_reward(model) <= 0


### PR DESCRIPTION
## Pull request checklist

- [ ] I have open an issue to discuss the proposed changes. Fix #
- [x] I have modified/added tests to cover the new changes/features.
- [x] I have modified/added the documentation to cover the new changes/features.
- [x] I have ran the tests, checks, and code formatters.

## Proposed implementation
NNodes reward: computes the difference in the total number of nodes between the previous and the current state. This is properly defined even considering B&B restarts, as the total number of B&B nodes from all restarts are accounted for.