### PR TITLE
Fixed LpIterations tests, reward must be non-negative

### DIFF
--- a/libecole/tests/src/reward/test-lpiterations.cpp
+++ b/libecole/tests/src/reward/test-lpiterations.cpp
@@ -19,7 +19,7 @@ TEST_CASE("LpIterations return the difference in LP iterations between two state
 	auto model = get_solving_model();
 	reward_func.reset(model);
 
-	SECTION("LP iterations are positive") { REQUIRE(reward_func.obtain_reward(model) >= 0); }
+	SECTION("LP iterations are positive") { REQUIRE(reward_func.obtain_reward(model) > 0); }
 
 	SECTION("LP iterations is zero if no solving happended between two states") {
 		reward_func.obtain_reward(model);
@@ -27,11 +27,13 @@ TEST_CASE("LpIterations return the difference in LP iterations between two state
 	}
 
 	SECTION("Reset LP iterations coutner") {
+		reward_func.obtain_reward(model);
+		REQUIRE(reward_func.obtain_reward(model) == 0);
 		reward_func.reset(model);
-		REQUIRE(reward_func.obtain_reward(model) >= 0);
+		REQUIRE(reward_func.obtain_reward(model) > 0);
 	}
 
-	SECTION("No iterations if SCIP is not solving LPs") {
+	SECTION("No LP iterations if SCIP is not solving LPs") {
 		model = get_model();
 		model.set_params({
 			{"presolving/maxrounds", 0},

--- a/libecole/tests/src/reward/test-lpiterations.cpp
+++ b/libecole/tests/src/reward/test-lpiterations.cpp
@@ -19,7 +19,7 @@ TEST_CASE("LpIterations return the difference in LP iterations between two state
 	auto model = get_solving_model();
 	reward_func.reset(model);
 
-	SECTION("LP iterations are positive") { REQUIRE(reward_func.obtain_reward(model) > 0); }
+	SECTION("LP iterations are positive") { REQUIRE(reward_func.obtain_reward(model) >= 0); }
 
 	SECTION("LP iterations is zero if no solving happended between two states") {
 		reward_func.obtain_reward(model);
@@ -27,10 +27,8 @@ TEST_CASE("LpIterations return the difference in LP iterations between two state
 	}
 
 	SECTION("Reset LP iterations coutner") {
-		reward_func.obtain_reward(model);
-		REQUIRE(reward_func.obtain_reward(model) == 0);
 		reward_func.reset(model);
-		REQUIRE(reward_func.obtain_reward(model) > 0);
+		REQUIRE(reward_func.obtain_reward(model) >= 0);
 	}
 
 	SECTION("No iterations if SCIP is not solving LPs") {

--- a/python/tests/test_reward.py
+++ b/python/tests/test_reward.py
@@ -56,4 +56,4 @@ def test_IsDone(model):
 def test_LpIterations(model):
     reward_func = R.LpIterations()
     reward_func.reset(model)
-    assert reward_func.obtain_reward(model) <= 0
+    assert reward_func.obtain_reward(model) >= 0


### PR DESCRIPTION
## Pull request checklist
- [x] I have ran the tests, checks, and code formatters.

## Proposed implementation
LpIterations was sometimes tested for negative values (<= 0), or for strictly positive values (> 0). The correct test is strictly non-negative ( >= 0). All tests pass.