### PR TITLE
Solvingtime

### DIFF
--- a/libecole/CMakeLists.txt
+++ b/libecole/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(
 	src/utility/reverse-control.cpp
 	src/reward/isdone.cpp
 	src/reward/lpiterations.cpp
+	src/reward/solvingtime.cpp
 	src/reward/nnodes.cpp
 	src/observation/nodebipartite.cpp
 	src/observation/strongbranchingscores.cpp

--- a/libecole/include/ecole/reward/solvingtime.hpp
+++ b/libecole/include/ecole/reward/solvingtime.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
 #include "ecole/reward/abstract.hpp"
-#include "ecole/scip/type.hpp"
 
 namespace ecole::reward {
 
 class SolvingTime : public RewardFunction {
 public:
-	SolvingTime(bool wall_ = false) : wall(wall_) {}
+	SolvingTime(bool wall_ = false) noexcept : wall(wall_) {}
+
 	void before_reset(scip::Model& model) override;
 	Reward extract(scip::Model& model, bool done = false) override;
 

--- a/libecole/include/ecole/reward/solvingtime.hpp
+++ b/libecole/include/ecole/reward/solvingtime.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "ecole/reward/abstract.hpp"
+#include "ecole/scip/type.hpp"
+
+namespace ecole::reward {
+
+class SolvingTime : public RewardFunction {
+public:
+	SolvingTime(bool wall_ = false) : wall(wall_) {}
+	void reset(scip::Model& model) override;
+	Reward obtain_reward(scip::Model& model, bool done = false) override;
+
+private:
+	bool const wall = false;
+	double solving_time_offset = 0;
+};
+
+}  // namespace ecole::reward

--- a/libecole/include/ecole/reward/solvingtime.hpp
+++ b/libecole/include/ecole/reward/solvingtime.hpp
@@ -8,12 +8,12 @@ namespace ecole::reward {
 class SolvingTime : public RewardFunction {
 public:
 	SolvingTime(bool wall_ = false) : wall(wall_) {}
-	void reset(scip::Model& model) override;
-	Reward obtain_reward(scip::Model& model, bool done = false) override;
+	void before_reset(scip::Model& model) override;
+	Reward extract(scip::Model& model, bool done = false) override;
 
 private:
-	bool const wall = false;
-	double solving_time_offset = 0;
+	bool wall = false;
+	long solving_time_offset = 0;
 };
 
 }  // namespace ecole::reward

--- a/libecole/src/reward/solvingtime.cpp
+++ b/libecole/src/reward/solvingtime.cpp
@@ -1,4 +1,5 @@
 #include <chrono>
+#include <iostream>
 
 #include "ecole/reward/solvingtime.hpp"
 #include "ecole/scip/model.hpp"
@@ -26,7 +27,7 @@ static auto process_solving_time(scip::Model const& model) {
 	}
 }
 
-void SolvingTime::reset(scip::Model const& model) {
+void SolvingTime::reset(scip::Model& model) {
 	model.set_params({{"timing/clocktype", 1}});
 
 	if (wall) {
@@ -34,11 +35,11 @@ void SolvingTime::reset(scip::Model const& model) {
 			std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch());
 		solving_time_offset = static_cast<double>(now_in_ms.count()) / MS_IN_SECONDS;
 	} else {
-		solving_time_offset = static_cast<double>(process_solving_time(model));
+		solving_time_offset = 0.;
 	}
 }
 
-Reward SolvingTime::obtain_reward(scip::Model const& model, bool /* done */) {
+Reward SolvingTime::obtain_reward(scip::Model& model, bool /* done */) {
 	double solving_time_diff;
 
 	if (wall) {

--- a/libecole/src/reward/solvingtime.cpp
+++ b/libecole/src/reward/solvingtime.cpp
@@ -1,0 +1,55 @@
+#include <chrono>
+
+#include "ecole/reward/solvingtime.hpp"
+#include "ecole/scip/model.hpp"
+
+namespace ecole::reward {
+
+const int MS_IN_SECONDS = 1000;
+
+static auto process_solving_time(scip::Model const& model) {
+	switch (model.get_stage()) {
+	// Only stages when the following call is authorized
+	case SCIP_STAGE_PROBLEM:
+	case SCIP_STAGE_TRANSFORMING:
+	case SCIP_STAGE_TRANSFORMED:
+	case SCIP_STAGE_INITPRESOLVE:
+	case SCIP_STAGE_PRESOLVING:
+	case SCIP_STAGE_EXITPRESOLVE:
+	case SCIP_STAGE_PRESOLVED:
+	case SCIP_STAGE_INITSOLVE:
+	case SCIP_STAGE_SOLVING:
+	case SCIP_STAGE_SOLVED:
+		return SCIPgetSolvingTime(model.get_scip_ptr());
+	default:
+		return decltype(SCIPgetSolvingTime(nullptr)){0};
+	}
+}
+
+void SolvingTime::reset(scip::Model const& model) {
+	model.set_params({{"timing/clocktype", 1}});
+
+	if (wall) {
+		auto now_in_ms =
+			std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch());
+		solving_time_offset = static_cast<double>(now_in_ms.count()) / MS_IN_SECONDS;
+	} else {
+		solving_time_offset = static_cast<double>(process_solving_time(model));
+	}
+}
+
+Reward SolvingTime::obtain_reward(scip::Model const& model, bool /* done */) {
+	double solving_time_diff;
+
+	if (wall) {
+		auto now_in_ms =
+			std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch());
+		solving_time_diff = static_cast<double>(now_in_ms.count()) / MS_IN_SECONDS - solving_time_offset;
+	} else {
+		solving_time_diff = static_cast<double>(process_solving_time(model)) - solving_time_offset;
+	}
+	solving_time_offset += solving_time_diff;
+	return solving_time_diff;
+}
+
+}  // namespace ecole::reward

--- a/libecole/src/reward/solvingtime.cpp
+++ b/libecole/src/reward/solvingtime.cpp
@@ -1,12 +1,11 @@
 #include <chrono>
-#include <iostream>
 
 #include "ecole/reward/solvingtime.hpp"
 #include "ecole/scip/model.hpp"
 
 namespace ecole::reward {
 
-const int MS_IN_SECONDS = 1000;
+const int MUS_IN_SECONDS = 1000000;
 
 static auto process_solving_time(scip::Model const& model) {
 	switch (model.get_stage()) {
@@ -31,9 +30,9 @@ void SolvingTime::reset(scip::Model& model) {
 	model.set_params({{"timing/clocktype", 1}});
 
 	if (wall) {
-		auto now_in_ms =
-			std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch());
-		solving_time_offset = static_cast<double>(now_in_ms.count()) / MS_IN_SECONDS;
+		auto now_in_mus = std::chrono::duration_cast<std::chrono::microseconds>(
+			std::chrono::high_resolution_clock::now().time_since_epoch());
+		solving_time_offset = static_cast<double>(now_in_mus.count()) / MUS_IN_SECONDS;
 	} else {
 		solving_time_offset = 0.;
 	}
@@ -43,9 +42,9 @@ Reward SolvingTime::obtain_reward(scip::Model& model, bool /* done */) {
 	double solving_time_diff;
 
 	if (wall) {
-		auto now_in_ms =
-			std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch());
-		solving_time_diff = static_cast<double>(now_in_ms.count()) / MS_IN_SECONDS - solving_time_offset;
+		auto now_in_mus = std::chrono::duration_cast<std::chrono::microseconds>(
+			std::chrono::high_resolution_clock::now().time_since_epoch());
+		solving_time_diff = static_cast<double>(now_in_mus.count()) / MUS_IN_SECONDS - solving_time_offset;
 	} else {
 		solving_time_diff = static_cast<double>(process_solving_time(model)) - solving_time_offset;
 	}

--- a/libecole/src/reward/solvingtime.cpp
+++ b/libecole/src/reward/solvingtime.cpp
@@ -1,4 +1,5 @@
 #include <chrono>
+#include <ctime>
 
 #include "ecole/reward/solvingtime.hpp"
 #include "ecole/scip/model.hpp"
@@ -7,48 +8,30 @@ namespace ecole::reward {
 
 const int MUS_IN_SECONDS = 1000000;
 
-static auto process_solving_time(scip::Model const& model) {
-	switch (model.get_stage()) {
-	// Only stages when the following call is authorized
-	case SCIP_STAGE_PROBLEM:
-	case SCIP_STAGE_TRANSFORMING:
-	case SCIP_STAGE_TRANSFORMED:
-	case SCIP_STAGE_INITPRESOLVE:
-	case SCIP_STAGE_PRESOLVING:
-	case SCIP_STAGE_EXITPRESOLVE:
-	case SCIP_STAGE_PRESOLVED:
-	case SCIP_STAGE_INITSOLVE:
-	case SCIP_STAGE_SOLVING:
-	case SCIP_STAGE_SOLVED:
-		return SCIPgetSolvingTime(model.get_scip_ptr());
-	default:
-		return decltype(SCIPgetSolvingTime(nullptr)){0};
-	}
-}
-
-void SolvingTime::reset(scip::Model& model) {
-	model.set_params({{"timing/clocktype", 1}});
+void SolvingTime::before_reset(scip::Model& /* model */) {
 
 	if (wall) {
-		auto now_in_mus = std::chrono::duration_cast<std::chrono::microseconds>(
-			std::chrono::high_resolution_clock::now().time_since_epoch());
-		solving_time_offset = static_cast<double>(now_in_mus.count()) / MUS_IN_SECONDS;
+		solving_time_offset =
+			std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now().time_since_epoch())
+				.count();
 	} else {
-		solving_time_offset = 0.;
+		solving_time_offset = std::clock();
 	}
 }
 
-Reward SolvingTime::obtain_reward(scip::Model& model, bool /* done */) {
+Reward SolvingTime::extract(scip::Model& /* model */, bool /* done */) {
 	double solving_time_diff;
+	long now;
 
 	if (wall) {
-		auto now_in_mus = std::chrono::duration_cast<std::chrono::microseconds>(
-			std::chrono::high_resolution_clock::now().time_since_epoch());
-		solving_time_diff = static_cast<double>(now_in_mus.count()) / MUS_IN_SECONDS - solving_time_offset;
+		now = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now().time_since_epoch())
+						.count();
+		solving_time_diff = double(now - solving_time_offset) / MUS_IN_SECONDS;
 	} else {
-		solving_time_diff = static_cast<double>(process_solving_time(model)) - solving_time_offset;
+		now = std::clock();
+		solving_time_diff = double(now - solving_time_offset) / CLOCKS_PER_SEC;
 	}
-	solving_time_offset += solving_time_diff;
+	solving_time_offset = now;
 	return solving_time_diff;
 }
 

--- a/libecole/tests/src/reward/test-solvingtime.cpp
+++ b/libecole/tests/src/reward/test-solvingtime.cpp
@@ -1,7 +1,5 @@
 #include <catch2/catch.hpp>
 
-#include "ecole/environment/branching.hpp"
-#include "ecole/observation/nothing.hpp"
 #include "ecole/reward/solvingtime.hpp"
 
 #include "conftest.hpp"
@@ -10,12 +8,12 @@
 using namespace ecole;
 
 TEST_CASE("SolvingTime unit tests", "[unit][reward]") {
-	bool wall = GENERATE(true, false);
+	bool const wall = GENERATE(true, false);
 	reward::unit_tests(reward::SolvingTime{wall});
 }
 
 TEST_CASE("Solving time rewards are positive initially", "[reward]") {
-	bool wall = GENERATE(true, false);
+	bool const wall = GENERATE(true, false);
 	auto reward_func = reward::SolvingTime{wall};
 	auto model = get_model();  // a non-trivial instance is loaded
 
@@ -28,26 +26,5 @@ TEST_CASE("Solving time rewards are positive initially", "[reward]") {
 		reward_func.reset(model);
 		model.solve_iter();  // presolve and stop at the root node before branching
 		REQUIRE(reward_func.obtain_reward(model) > 0);
-	}
-}
-
-TEST_CASE("Solving time rewards are always strictly positive when used in a Branching environment", "[reward]") {
-	constexpr int max_nnodes = 20;
-	bool wall = GENERATE(true, false);
-	auto env = environment::Branching<observation::Nothing, reward::SolvingTime>{
-		{},
-		{reward::SolvingTime{wall}},
-		{
-			{"presolving/maxrounds", 0},  // just to save time here
-			{"limits/totalnodes", max_nnodes},
-		},
-		false};
-
-	auto [obs, action_set, reward, done] = env.reset(problem_file);
-	REQUIRE(reward > 0);
-
-	while (!done) {
-		std::tie(std::ignore, action_set, reward, done, std::ignore) = env.step(action_set.value()[0]);  // dumb action
-		REQUIRE(reward >= 0);
 	}
 }

--- a/libecole/tests/src/reward/test-solvingtime.cpp
+++ b/libecole/tests/src/reward/test-solvingtime.cpp
@@ -1,5 +1,7 @@
 #include <catch2/catch.hpp>
 
+#include "ecole/environment/branching.hpp"
+#include "ecole/observation/nothing.hpp"
 #include "ecole/reward/solvingtime.hpp"
 
 #include "conftest.hpp"
@@ -32,9 +34,9 @@ TEST_CASE("Solving time rewards are positive initially", "[reward]") {
 TEST_CASE("Solving time rewards are always strictly positive when used in a Branching environment", "[reward]") {
 	constexpr int max_nnodes = 20;
 	bool wall = GENERATE(true, false);
-	auto env = environment::Branching<observation::Nothing, reward::SolvingTime{wall}>{
+	auto env = environment::Branching<observation::Nothing, reward::SolvingTime>{
 		{},
-		{},
+		{reward::SolvingTime{wall}},
 		{
 			{"presolving/maxrounds", 0},  // just to save time here
 			{"limits/totalnodes", max_nnodes},

--- a/libecole/tests/src/reward/test-solvingtime.cpp
+++ b/libecole/tests/src/reward/test-solvingtime.cpp
@@ -41,19 +41,13 @@ TEST_CASE("Solving time rewards are always strictly positive when used in a Bran
 			{"presolving/maxrounds", 0},  // just to save time here
 			{"limits/totalnodes", max_nnodes},
 		},
-		true};
+		false};
 
-	for (auto i = 0; i < 2; ++i) {
-		auto [obs, action_set, reward, done] = env.reset(problem_file);
+	auto [obs, action_set, reward, done] = env.reset(problem_file);
+	REQUIRE(reward > 0);
 
-		// Assert that the number of nodes is strictly positive
-		REQUIRE(reward > 0);
-
-		while (!done) {
-			std::tie(std::ignore, action_set, reward, done, std::ignore) = env.step(action_set.value()[0]);  // dumb action
-
-			// Assert that the increase in solving time is strictly positive
-			REQUIRE(reward > 0);
-		}
+	while (!done) {
+		std::tie(std::ignore, action_set, reward, done, std::ignore) = env.step(action_set.value()[0]);  // dumb action
+		REQUIRE(reward >= 0);
 	}
 }

--- a/libecole/tests/src/reward/test-solvingtime.cpp
+++ b/libecole/tests/src/reward/test-solvingtime.cpp
@@ -1,0 +1,57 @@
+#include <catch2/catch.hpp>
+
+#include "ecole/reward/solvingtime.hpp"
+
+#include "conftest.hpp"
+#include "reward/unit-tests.hpp"
+
+using namespace ecole;
+
+TEST_CASE("SolvingTime unit tests", "[unit][reward]") {
+	bool wall = GENERATE(true, false);
+	reward::unit_tests(reward::SolvingTime{wall});
+}
+
+TEST_CASE("Solving time rewards are positive initially", "[reward]") {
+	bool wall = GENERATE(true, false);
+	auto reward_func = reward::SolvingTime{wall};
+	auto model = get_model();  // a non-trivial instance is loaded
+
+	SECTION("Solving time is nonnegative before presolving") {
+		reward_func.reset(model);
+		REQUIRE(reward_func.obtain_reward(model) >= 0);
+	}
+
+	SECTION("Solving time is stricly positive after root node processing") {
+		reward_func.reset(model);
+		model.solve_iter();  // presolve and stop at the root node before branching
+		REQUIRE(reward_func.obtain_reward(model) > 0);
+	}
+}
+
+TEST_CASE("Solving time rewards are always strictly positive when used in a Branching environment", "[reward]") {
+	constexpr int max_nnodes = 20;
+	bool wall = GENERATE(true, false);
+	auto env = environment::Branching<observation::Nothing, reward::SolvingTime{wall}>{
+		{},
+		{},
+		{
+			{"presolving/maxrounds", 0},  // just to save time here
+			{"limits/totalnodes", max_nnodes},
+		},
+		true};
+
+	for (auto i = 0; i < 2; ++i) {
+		auto [obs, action_set, reward, done] = env.reset(problem_file);
+
+		// Assert that the number of nodes is strictly positive
+		REQUIRE(reward > 0);
+
+		while (!done) {
+			std::tie(std::ignore, action_set, reward, done, std::ignore) = env.step(action_set.value()[0]);  // dumb action
+
+			// Assert that the increase in solving time is strictly positive
+			REQUIRE(reward > 0);
+		}
+	}
+}

--- a/python/src/ecole/core/reward.cpp
+++ b/python/src/ecole/core/reward.cpp
@@ -7,6 +7,7 @@
 #include "ecole/reward/isdone.hpp"
 #include "ecole/reward/lpiterations.hpp"
 #include "ecole/reward/nnodes.hpp"
+#include "ecole/reward/solvingtime.hpp"
 #include "ecole/scip/model.hpp"
 
 #include "core.hpp"
@@ -115,7 +116,7 @@ void bind_submodule(py::module_ const& m) {
 	def_extract(isdone, "Return 1 if the episode is on a terminal state, 0 otherwise.");
 
 	auto lpiterations = py::class_<LpIterations>(m, "LpIterations", R"(
-		LP Iteration difference.
+		LP iterations difference.
 
 		The reward is defined as the number of iterations spent in solving the Linear Programs
 		associated with the problem since the previous state.
@@ -141,6 +142,31 @@ void bind_submodule(py::module_ const& m) {
 		Update the internal node count and return the difference.
 
 		The difference in number of nodes is computed in between calls.
+		)");
+
+	auto solvingtime = py::class_<SolvingTime>(m, "SolvingTime", R"(
+		Solving time difference.
+
+		The reward is defined as the amount of time spent solving the instance since the previous state.
+        The solving time is maintained internally by SCIP and is specific to the operating system: it
+        includes presolving and time spent waiting on the agent.
+
+        N.B. Using this reward function will overwrite the `timing/clocktype` SCIP parameter.
+	)");
+	solvingtime.def(py::init<bool>(), py::arg("wall") = false, R"(
+		Constructor for SolvingTime.
+
+		Parameters
+		----------
+		wall : bool, optional
+			If true, the wall time will be used. If False (default), the process time will be used.
+	)");
+	def_operators(solvingtime);
+	def_reset(solvingtime, "Reset the internal clock counter.");
+	def_obtain_reward(solvingtime, R"(
+		Update the internal clock counter and return the difference.
+
+		The difference in solving time is computed in between calls.
 		)");
 }
 

--- a/python/src/ecole/core/reward.cpp
+++ b/python/src/ecole/core/reward.cpp
@@ -148,18 +148,17 @@ void bind_submodule(py::module_ const& m) {
 		Solving time difference.
 
 		The reward is defined as the amount of time spent solving the instance since the previous state.
-        The solving time is maintained internally by SCIP and is specific to the operating system: it
-        includes presolving and time spent waiting on the agent.
-
-        N.B. Using this reward function will overwrite the `timing/clocktype` SCIP parameter.
+		The solving time is specific to the operating system: it includes time spent in
+		:py:meth:`~ecole.environment.Environment.reset` and time spent waiting on the agent.
 	)");
 	solvingtime.def(py::init<bool>(), py::arg("wall") = false, R"(
-		Constructor for SolvingTime.
+		Create a SolvingTime reward function.
 
 		Parameters
 		----------
 		wall :
 			If true, the wall time will be used. If False (default), the process time will be used.
+
 	)");
 	def_operators(solvingtime);
 	def_before_reset(solvingtime, "Reset the internal clock counter.");

--- a/python/src/ecole/core/reward.cpp
+++ b/python/src/ecole/core/reward.cpp
@@ -158,12 +158,12 @@ void bind_submodule(py::module_ const& m) {
 
 		Parameters
 		----------
-		wall : bool, optional
+		wall :
 			If true, the wall time will be used. If False (default), the process time will be used.
 	)");
 	def_operators(solvingtime);
-	def_reset(solvingtime, "Reset the internal clock counter.");
-	def_obtain_reward(solvingtime, R"(
+	def_before_reset(solvingtime, "Reset the internal clock counter.");
+	def_extract(solvingtime, R"(
 		Update the internal clock counter and return the difference.
 
 		The difference in solving time is computed in between calls.


### PR DESCRIPTION
## Pull request checklist
- [x] I have open an issue to discuss the proposed changes. Fix #
- [x] I have modified/added tests to cover the new changes/features.
- [ ] I have modified/added the documentation to cover the new changes/features.
- [x] I have ran the tests, checks, and code formatters.

## Proposed implementation
Implementation of solving time reward `ecole.reward.SolvingTime()`. Can take an optional boolean parameter `wall` to decide whether one wants to use wall time or process time (default).

I think it is worthwhile to explain a bit the design decisions. As we all know, timing is tricky. Here were goals that I tried to balance:

- One of the timing rewards should match what was used to report timings in the learn2branch paper (gold standard).
- If we offer several timing rewards, it should be possible for the user to run them all simultaneously on the same environment (e.g. to report both wall and process times).

It turns out that this is not easy to do. I think my implementation does a good job given those constraints, while trying to be as simple as possible. Here's how I ended up implementing, with some warnings:

1. The process time version (default) uses SCIP's internal clock counter, via `SCIPgetSolvingTime`. This makes it identical with the timings reported in the learn2branch paper, which is nice for consistency. Unfortunately, I also need to set a global SCIP parameter,  `timings/clocktype=1`, to make sure the clock reports correctly the process time. I ended up having the reset function setting this parameter manually. 

    This means the following delicate thing: if a user sets `timings/clocktype`, _and_ also decides to use    `ecole.reward.SolvingTime()`, then **the user parameter setting will be overridden**. So it's important the user is made aware of this. Ultimately, the problem is that SCIP's developers decided to control this setting with a global parameter, so we are in some sense stuck with SCIP's poor design choice. However, I should point out that we already override other SCIP parameters (mostly having to do with seeding), so the idea that Ecole can override user parameters is not new.

2. Because SCIP only has one internal clock counter, which is controlled by the global `timings/clocktype` parameter, it is not actually possible to use SCIP to get both wall time and process time simultaneously! So I decided to do like in the learn2branch evaluation code implementation, and use a standard library to get wall time instead. Since this is a C++ implementation, I ended up using the `chrono` library, which is portable across operating systems and part of the standard library since C++11. This is somewhat analogous to using the `time` Python library, which was used in the learn2branch implementation.

3. However, this leads to also another tricky detail. To compute the timings accurately with a non-SCIP timer, I need to start it right before the solving starts. The natural place to put it is in the reward `reset` function, but unfortunately the `python/src/ecole/environment.py` code has this in the master branch:
    ```python
    done, action_set = self.dynamics.reset_dynamics(
        self.model, *dynamics_args, **dynamics_kwargs
    )
    self.observation_function.reset(self.model)
    self.reward_function.reset(self.model)
    ```
    So the reward's `reset` function is called _after_ the preprocessing/root LP solving is done! (Which is in the dynamics resetting.) So we would need to invert the order,
    ```python
    self.reward_function.reset(self.model)
    self.observation_function.reset(self.model)
    done, action_set = self.dynamics.reset_dynamics(
        self.model, *dynamics_args, **dynamics_kwargs
    )
    ```
    Also, same thing for the C++ API.
    This is a breaking change that affects the whole of Ecole, so it would be significant. I checked and no reward function would be significantly affected by this, but it would be important to keep in mind for the future that this specific order is needed, `reward.reset` before `dynamics.reset_dynamics`. (Note that getting the actual initial reward is not done by reset but by `obtain_reward`, which is done later. For the reward functions so far, the reset merely initializes counters to zero.)

    Finally, when there is a future "info field", it would be important that the metric's `reset` functions also be called before the resetting of the dynamics.

Now, I can see alternative ways of doing things, which have their own downsides, but it's always good to discuss them.

- For the `wall=False` process time case, instead of using SCIP, we could also use a non-SCIP library call. The main advantage I see of doing that is that we wouldn't have to override the `timing/clocktype` parameter. The downside I see is that we break with learn2branch. (This would be analogous to having reported `time.process_time` instead of `SCIPgetSolvingTime` back when writing the learn2branch paper.)
- For the ordering of the resets, another possibility would be to add internal clocks in Ecole that would run regardless of what reward function gets used. The solving time rewards, when used, would then just check on those clocks. The big advantage of doing that is that we would then be decoupling the clock management (initializing the clocks) from the rewards `reset` functions, and make it independent of the ordering of the resets. The downside I see is that it would make the code more complicated - we would have basically a new clock management module in Ecole. Is it worth it?