### PR TITLE
Refactor solving time to use cpu_clock

### DIFF
--- a/libecole/CMakeLists.txt
+++ b/libecole/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(
 	src/random.cpp
 	src/exception.cpp
 	src/utility/reverse-control.cpp
+	src/utility/chrono.cpp
 	src/scip/scimpl.cpp
 	src/scip/model.cpp
 	src/scip/exception.cpp

--- a/libecole/include/ecole/reward/solvingtime.hpp
+++ b/libecole/include/ecole/reward/solvingtime.hpp
@@ -1,19 +1,21 @@
 #pragma once
 
+#include <chrono>
+
 #include "ecole/reward/abstract.hpp"
 
 namespace ecole::reward {
 
 class SolvingTime : public RewardFunction {
 public:
-	SolvingTime(bool wall_ = false) noexcept : wall(wall_) {}
+	SolvingTime(bool wall_ = false) noexcept : wall{wall_} {}
 
 	void before_reset(scip::Model& model) override;
 	Reward extract(scip::Model& model, bool done = false) override;
 
 private:
 	bool wall = false;
-	long solving_time_offset = 0;
+	std::chrono::nanoseconds solving_time_offset;
 };
 
 }  // namespace ecole::reward

--- a/libecole/include/ecole/utility/chrono.hpp
+++ b/libecole/include/ecole/utility/chrono.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <chrono>
+
+namespace ecole::utility {
+
+/**
+ * A CPU usage clock.
+ *
+ * Measure time the CPU spent processing the program’s instructions.
+ * This count both the System (kernel) and User CPU time.
+ * The time spent waiting for other things to complete (like I/O operations) is not included in the CPU time.
+ *
+ * The implementation uses OS dependent functionality.
+ */
+class cpu_clock {
+public:
+	using duration = std::chrono::nanoseconds;
+	using rep = duration::rep;
+	using period = duration::period;
+	using time_point = std::chrono::time_point<cpu_clock>;
+	static bool constexpr is_steady = true;
+
+	static auto now() -> time_point;
+};
+
+}  // namespace ecole::utility

--- a/libecole/src/reward/solvingtime.cpp
+++ b/libecole/src/reward/solvingtime.cpp
@@ -1,39 +1,28 @@
 #include <chrono>
-#include <ctime>
 
 #include "ecole/reward/solvingtime.hpp"
+#include "ecole/utility/chrono.hpp"
 
 namespace ecole::reward {
 
 namespace {
 
-auto wall_clock() {
-	return std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now().time_since_epoch())
-		.count();
+auto time_now(bool wall) -> std::chrono::nanoseconds {
+	if (wall) {
+		return std::chrono::steady_clock::now().time_since_epoch();
+	}
+	return utility::cpu_clock::now().time_since_epoch();
 }
 
 }  // namespace
 
 void SolvingTime::before_reset(scip::Model& /* model */) {
-	if (wall) {
-		solving_time_offset = wall_clock();
-	} else {
-		solving_time_offset = static_cast<long>(std::clock());
-	}
+	solving_time_offset = time_now(wall);
 }
 
 Reward SolvingTime::extract(scip::Model& /* model */, bool /* done */) {
-	double solving_time_diff = 0.0;
-	long now = 0;
-
-	if (wall) {
-		static auto constexpr mus_per_seconds = 1000 * 1000;
-		now = wall_clock();
-		solving_time_diff = static_cast<double>(now - solving_time_offset) / mus_per_seconds;
-	} else {
-		now = static_cast<long>(std::clock());
-		solving_time_diff = static_cast<double>(now - solving_time_offset) / CLOCKS_PER_SEC;
-	}
+	auto const now = time_now(wall);
+	auto const solving_time_diff = static_cast<double>((now - solving_time_offset).count());
 	solving_time_offset = now;
 	return solving_time_diff;
 }

--- a/libecole/src/reward/solvingtime.cpp
+++ b/libecole/src/reward/solvingtime.cpp
@@ -22,7 +22,8 @@ void SolvingTime::before_reset(scip::Model& /* model */) {
 
 Reward SolvingTime::extract(scip::Model& /* model */, bool /* done */) {
 	auto const now = time_now(wall);
-	auto const solving_time_diff = static_cast<double>((now - solving_time_offset).count());
+	// Casting to seconds represented as a Reward (no ratio).
+	auto const solving_time_diff = std::chrono::duration<Reward>{now - solving_time_offset}.count();
 	solving_time_offset = now;
 	return solving_time_diff;
 }

--- a/libecole/src/utility/chrono.cpp
+++ b/libecole/src/utility/chrono.cpp
@@ -1,0 +1,28 @@
+#include <cerrno>
+#include <ctime>
+#include <system_error>
+
+#include "ecole/utility/chrono.hpp"
+
+namespace ecole::utility {
+
+/**
+ * There is no standard way to get CPU time.
+ *
+ * The following implementation is inspired from
+ *  - https://levelup.gitconnected.com/8-ways-to-measure-execution-time-in-c-c-48634458d0f9
+ *  - https://stackoverflow.com/a/12480485/5862073
+ *  - Google Benchmark implementation
+ *    https://github.com/google/benchmark/blob/8df87f6c879cbcabd17c5cfcec7b89687df36953/src/timers.cc#L110
+ */
+auto cpu_clock::now() -> time_point {
+	// Using clock_gettime is not standard but POSIX. It has nanoseconds resolution.
+	// It works on Linux and MacOS >= 10.12
+	struct timespec spec;
+	if (clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &spec) != 0) {
+		throw std::system_error{{errno, std::generic_category()}};
+	}
+	return time_point{std::chrono::seconds{spec.tv_sec} + std::chrono::nanoseconds{spec.tv_nsec}};
+}
+
+}  // namespace ecole::utility

--- a/libecole/tests/CMakeLists.txt
+++ b/libecole/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(
 	src/reward/test-lpiterations.cpp
 	src/reward/test-isdone.cpp
 	src/reward/test-nnodes.cpp
+	src/reward/test-solvingtime.cpp
 
 	src/observation/test-nodebipartite.cpp
 	src/observation/test-strongbranchingscores.cpp

--- a/libecole/tests/CMakeLists.txt
+++ b/libecole/tests/CMakeLists.txt
@@ -8,6 +8,8 @@ add_executable(
 	src/test-traits.cpp
 	src/test-random.cpp
 
+	src/utility/test-chrono.cpp
+
 	src/scip/test-scimpl.cpp
 	src/scip/test-model.cpp
 

--- a/libecole/tests/src/utility/test-chrono.cpp
+++ b/libecole/tests/src/utility/test-chrono.cpp
@@ -1,0 +1,11 @@
+#include <catch2/catch.hpp>
+
+#include "ecole/utility/chrono.hpp"
+
+using namespace ecole;
+
+TEST_CASE("cpu_clock is monotonic", "[utility]") {
+	auto const before = utility::cpu_clock::now();
+	auto const after = utility::cpu_clock::now();
+	REQUIRE(before < after);
+}

--- a/python/src/ecole/core/reward.cpp
+++ b/python/src/ecole/core/reward.cpp
@@ -147,7 +147,7 @@ void bind_submodule(py::module_ const& m) {
 	auto solvingtime = py::class_<SolvingTime>(m, "SolvingTime", R"(
 		Solving time difference.
 
-		The reward is defined as the amount of time spent solving the instance since the previous state.
+		The reward is defined as the number of seconds spent solving the instance since the previous state.
 		The solving time is specific to the operating system: it includes time spent in
 		:py:meth:`~ecole.environment.Environment.reset` and time spent waiting on the agent.
 	)");


### PR DESCRIPTION
## Pull request checklist
- [ ] ~I have open an issue to discuss the proposed changes. Fix #~
- [x] I have modified/added tests to cover the new changes/features.
- [x] I have modified/added the documenation to cover the new changes/features.
- [x] I have ran the tests, checks, and code formatters.

## Proposed implementation
I am also needing to time CPU for benchmarking the observation functions so I made it into a `clock`.
I switched to `clock_gettime`, even though it is not standard as it has higher resolution (nano vs micro?).
`std::clock` is allegedly not giving CPU time on Windows anyways.

One question remains. What should be the unit of `SolvingTime`? Previously it was in miliseconds. In this PR, it is currently in nanoseconds.
While we may not need that much precision, there is also little need make the approximation to miliseconds earlier than necessary. It can easily be done using `SolvingTime() / 1e6`.
