### PR TITLE
Add manual cache to NodeBipartite

### DIFF
--- a/libecole/include/ecole/observation/nodebipartite.hpp
+++ b/libecole/include/ecole/observation/nodebipartite.hpp
@@ -64,11 +64,14 @@ class NodeBipartite : public ObservationFunction<std::optional<NodeBipartiteObs>
 public:
 	NodeBipartite(bool cache = false) : use_cache{cache} {}
 
+	void before_reset(scip::Model& model) override;
+
 	std::optional<NodeBipartiteObs> extract(scip::Model& model, bool done) override;
 
 private:
 	NodeBipartiteObs the_cache;
 	bool use_cache = false;
+	bool cache_computed = false;
 };
 
 }  // namespace ecole::observation

--- a/libecole/include/ecole/observation/nodebipartite.hpp
+++ b/libecole/include/ecole/observation/nodebipartite.hpp
@@ -62,7 +62,13 @@ public:
 
 class NodeBipartite : public ObservationFunction<std::optional<NodeBipartiteObs>> {
 public:
+	NodeBipartite(bool cache = false) : use_cache{cache} {}
+
 	std::optional<NodeBipartiteObs> extract(scip::Model& model, bool done) override;
+
+private:
+	NodeBipartiteObs the_cache;
+	bool use_cache = false;
 };
 
 }  // namespace ecole::observation

--- a/libecole/src/observation/nodebipartite.cpp
+++ b/libecole/src/observation/nodebipartite.cpp
@@ -375,14 +375,21 @@ auto extract_observation_from_cache(scip::Model& model, NodeBipartiteObs obs) ->
  *  Observation extracting function  *
  *************************************/
 
+auto NodeBipartite::before_reset(scip::Model & /* model */) -> void {
+	cache_computed = false;
+}
+
 auto NodeBipartite::extract(scip::Model& model, bool /* done */) -> std::optional<NodeBipartiteObs> {
 	if (model.get_stage() == SCIP_STAGE_SOLVING) {
 		if (use_cache) {
 			if (is_on_root_node(model)) {
 				the_cache = extract_observation_fully(model);
+				cache_computed = true;
 				return the_cache;
 			}
-			return extract_observation_from_cache(model, the_cache);
+			if (cache_computed) {
+				return extract_observation_from_cache(model, the_cache);
+			}
 		}
 		return extract_observation_fully(model);
 	}

--- a/libecole/tests/src/observation/test-nodebipartite.cpp
+++ b/libecole/tests/src/observation/test-nodebipartite.cpp
@@ -16,8 +16,12 @@ TEST_CASE("NodeBipartite unit tests", "[unit][obs]") {
 }
 
 TEST_CASE("NodeBipartite return correct observation", "[obs]") {
-	auto obs_func = observation::NodeBipartite{};
+	auto cache = GENERATE(true, false);
+	auto obs_func = observation::NodeBipartite{cache};
 	auto model = get_model();
+	if (cache) {
+		model.disable_cuts();
+	}
 	obs_func.before_reset(model);
 	advance_to_root_node(model);
 	auto const optional_obs = obs_func.extract(model, false);

--- a/python/src/ecole/core/observation.cpp
+++ b/python/src/ecole/core/observation.cpp
@@ -138,7 +138,15 @@ void bind_submodule(py::module_ const& m) {
 
 		This observation function extract structured :py:class:`NodeBipartiteObs`.
 	)");
-	node_bipartite.def(py::init<>());
+	node_bipartite.def(py::init<bool>(), py::arg("cache") = false, R"(
+		Initialize the logger.
+
+		Parameters
+		----------
+		cache :
+			Whether or not to cache static features within an episode.
+			Currently, this is only safe if cutting planes are disabled.
+	)");
 	def_before_reset(node_bipartite, "Cache some feature not expected to change during an episode.");
 	def_extract(node_bipartite, "Extract a new :py:class:`NodeBipartiteObs`.");
 


### PR DESCRIPTION
## Pull request checklist
<!---
Thank you for contributing to Ecole!

⚠️ To ensure a smooth review, please make sure to complete the following checklist. ⚠️

Except for very small fixes, please open an issue to discuss the changes and fill
the number bellow.
Refer to the README for help on running the tests, checks, formatters, and documentation.
-->
- [x] I have open an issue to discuss the proposed changes. Fix #78
- [x] I have modified/added tests to cover the new changes/features.
- [x] I have modified/added the documentation to cover the new changes/features.
- [x] I have ran the tests, checks, and code formaters.

## Proposed implementation
This add a manual cache to `NodeBipartite` similar to _Gasse et al._ (2019).
The cache is only safe to use when not using cuts.

Future improvements would include:
 - Automatically detect when we can activate the cache;
 - Always enable the cache but detect when the cache is invalid within an episode (is it worth it);
 - Have a dynamic per row / per col cache that can reuse previous computation even if the structure of the problem has changed.
