### PR TITLE
Dual Bound

### DIFF
--- a/libecole/CMakeLists.txt
+++ b/libecole/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(
 	src/reward/lpiterations.cpp
 	src/reward/solvingtime.cpp
 	src/reward/nnodes.cpp
+  src/reward/dualbound.cpp
 
 	src/observation/nodebipartite.cpp
 	src/observation/khalil-2016.cpp

--- a/libecole/include/ecole/reward/dualbound.hpp
+++ b/libecole/include/ecole/reward/dualbound.hpp
@@ -3,6 +3,8 @@
 #include "ecole/reward/abstract.hpp"
 #include "ecole/scip/type.hpp"
 
+#define infinity   1e+20
+
 namespace ecole::reward {
 
 class DualBound : public RewardFunction {
@@ -11,8 +13,8 @@ public:
 	Reward extract(scip::Model& model, bool done = false) override;
 
 private:
-	scip::real dual_bound_value = 0.0;
-//	scip::real dual_bound_value = Infinity;
+//	scip::real dual_bound_value = 0.0;
+	scip::real dual_bound_value = - infinity;
 };
 
 }  // namespace ecole::reward

--- a/libecole/include/ecole/reward/dualbound.hpp
+++ b/libecole/include/ecole/reward/dualbound.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "ecole/reward/abstract.hpp"
+#include "ecole/scip/type.hpp"
+
+namespace ecole::reward {
+
+class DualBound : public RewardFunction {
+public:
+	void before_reset(scip::Model& model) override;
+	Reward extract(scip::Model& model, bool done = false) override;
+
+private:
+	scip::real dual_bound_value = 0.0;
+//	scip::real dual_bound_value = Infinity;
+};
+
+}  // namespace ecole::reward

--- a/libecole/src/reward/dualbound.cpp
+++ b/libecole/src/reward/dualbound.cpp
@@ -1,0 +1,34 @@
+#include "ecole/reward/dualbound.hpp"
+#include "ecole/scip/model.hpp"
+
+#define infinity   1e+20
+
+namespace ecole::reward {
+
+static auto dual_bound(scip::Model& model) {
+	switch (model.get_stage()) {
+	// Only stages when the following call is authorized
+	case SCIP_STAGE_TRANSFORMED:
+  case SCIP_STAGE_INITPRESOLVE:
+  case SCIP_STAGE_PRESOLVING:
+  case SCIP_STAGE_EXITPRESOLVE:
+  case SCIP_STAGE_PRESOLVED:
+  case SCIP_STAGE_INITSOLVE:
+  case SCIP_STAGE_SOLVING:
+  case SCIP_STAGE_SOLVED:
+		return SCIPgetDualbound(model.get_scip_ptr());
+	default:
+		return decltype(SCIPgetDualbound(nullptr)){0};
+	}
+}
+
+void DualBound::before_reset(scip::Model& /*Model*/) {
+  	dual_bound_value = - infinity;
+}
+
+Reward DualBound::extract(scip::Model& model, bool /* done */) {
+	auto dual_bound_value = dual_bound(model);
+	return static_cast<double>(dual_bound_value);
+}
+
+}  // namespace ecole::reward

--- a/libecole/src/reward/dualbound.cpp
+++ b/libecole/src/reward/dualbound.cpp
@@ -1,8 +1,6 @@
 #include "ecole/reward/dualbound.hpp"
 #include "ecole/scip/model.hpp"
 
-#define infinity   1e+20
-
 namespace ecole::reward {
 
 static auto dual_bound(scip::Model& model) {
@@ -27,8 +25,8 @@ void DualBound::before_reset(scip::Model& /*Model*/) {
 }
 
 Reward DualBound::extract(scip::Model& model, bool /* done */) {
-	auto dual_bound_value = dual_bound(model);
-	return static_cast<double>(dual_bound_value);
+	auto dualBound_value = dual_bound(model);
+	return static_cast<double>(dualBound_value);
 }
 
 }  // namespace ecole::reward

--- a/libecole/tests/CMakeLists.txt
+++ b/libecole/tests/CMakeLists.txt
@@ -34,6 +34,8 @@ add_executable(
 	src/reward/test-isdone.cpp
 	src/reward/test-nnodes.cpp
 	src/reward/test-solvingtime.cpp
+	src/reward/test-dualbound.cpp
+
 
 	src/observation/test-nodebipartite.cpp
 	src/observation/test-strongbranchingscores.cpp

--- a/libecole/tests/src/reward/test-dualbound.cpp
+++ b/libecole/tests/src/reward/test-dualbound.cpp
@@ -1,0 +1,36 @@
+#include <catch2/catch.hpp>
+
+#include "ecole/reward/dualbound.hpp"
+
+#include "conftest.hpp"
+#include "reward/unit-tests.hpp"
+
+using namespace ecole;
+
+TEST_CASE("DualBound unit tests", "[unit][reward]") {
+	reward::unit_tests(reward::DualBound{});
+}
+
+TEST_CASE("DualBound returns the dyal bound value", "[reward]") {
+	auto reward_func = reward::DualBound{};
+	auto model = get_model();  // a non-trivial instance is loaded
+
+	SECTION("DualBound iterations is infinity before presolving") {
+		reward_func.before_reset(model);
+//    REQUIRE(reward_func.extract(model) == Infinity);
+	}
+	
+	
+	SECTION("No dual bound value if SCIP is not solving LPs") {
+		model = get_model();
+		model.set_params({
+			{"presolving/maxrounds", 0},
+			{"lp/iterlim", 0},
+			{"lp/rootiterlim", 0},
+			{"limits/totalnodes", 1},
+		});
+		advance_to_root_node(model);
+		reward_func.before_reset(model);
+//		REQUIRE(reward_func.extract(model) == Infinity);
+	}
+}

--- a/python/src/ecole/core/reward.cpp
+++ b/python/src/ecole/core/reward.cpp
@@ -8,6 +8,7 @@
 #include "ecole/reward/lpiterations.hpp"
 #include "ecole/reward/nnodes.hpp"
 #include "ecole/reward/solvingtime.hpp"
+#include "ecole/reward/dualbound.hpp"
 #include "ecole/scip/model.hpp"
 
 #include "core.hpp"
@@ -167,6 +168,19 @@ void bind_submodule(py::module_ const& m) {
 
 		The difference in solving time is computed in between calls.
 		)");
+	
+	auto dualbound = py::class_<DualBound>(m, "DualBound", R"(
+		dual bound.
+
+		The reward is defined as the value of dual bound.
+	)");
+	dualbound.def(py::init<>());
+	def_operators(dualbound);
+	def_before_reset(dualbound, "Reset the dual bound : set -infinity.");
+	def_extract(dualbound, R"(
+		Extarct the dual bound.
+		)");
+
 }
 
 /******************************

--- a/python/tests/test_reward.py
+++ b/python/tests/test_reward.py
@@ -24,6 +24,7 @@ def pytest_generate_tests(metafunc):
             ecole.reward.Constant(),
             ecole.reward.IsDone(),
             ecole.reward.LpIterations(),
+            ecole.reward.DualBound(),
         )
         metafunc.parametrize("reward_function", all_reward_functions)
 


### PR DESCRIPTION
## Pull request checklist
Did I miss something ?  

C++
- [x] Create dualBound.hpp 
- [x] Create  dualBound.cpp 
- [x] Add an entry in libecole/CMakeLists.txt.

C++ test :
- [x] Create test-dualbound.cpp 
- [x] Add an entry in libecole/tests/CMakeLists.txt.

Python
- [x] Enable using the new reward 
- [x] Test with python

## HelloWorld implementation
<!-- A clear and concise description of your implementation. -->

To add a helloWorld Reward (resp. observation) function :
- [ ] Create helloWorld.hpp in libecole/include/ecole/reward  (resp. libecole/include/ecole/observation)
- [ ] Create  helloWorld.cpp in libecole/src/reward  (resp. in libecole/src/observation).
- [ ] Add an entry in libecole/CMakeLists.txt.

To test  c++ helloWorld Reward (resp. observation) function :
- [ ] Create test-helloworld.cpp in libecole/tests/src/reward  (resp. libecole//tests/src/observation)
- [ ] Add an entry in libecole/tests/CMakeLists.txt.

To enable using the new reward (resp observation) with python 
- [ ] Add entries in python/src/ecole/core/reward.cpp (resp. python/src/ecole/core/observation.cpp)

#include "ecole/reward/helloWorld.hpp"
and

auto helloworld= py::class_<HelloWorld>(m, "HelloWorld", R"(		
		The reward (observation) is helloworld .
	)");
	helloworld.def(py::init<>());
	def_operators(helloworld);
	def_before_reset(helloworld, "Reset the helloworld.");
	def_extract(helloworld, R"(
		Extarct the helloworld.
		)");



To test python helloWorld Reward (resp. observation) function :
- [ ] add entries in python/tests/test_reward.py (resp. python/tests/test_observation.py)
