### PR TITLE
Bugfix: instance generator for capacitated facility location

### DIFF
--- a/libecole/include/ecole/instance/capacitated-facility-location.hpp
+++ b/libecole/include/ecole/instance/capacitated-facility-location.hpp
@@ -13,7 +13,7 @@ public:
 	struct Parameters {
 		std::size_t n_customers = 100;                                   // NOLINT(readability-magic-numbers)
 		std::size_t n_facilities = 100;                                  // NOLINT(readability-magic-numbers)
-		bool continuous_assignment = false;                              // NOLINT(readability-magic-numbers)
+		bool continuous_assignment = true;                               // NOLINT(readability-magic-numbers)
 		double ratio = 5.0;                                              // NOLINT(readability-magic-numbers)
 		std::pair<int, int> demand_interval = {5, 35 + 1};               // NOLINT(readability-magic-numbers)
 		std::pair<int, int> capacity_interval = {10, 160 + 1};           // NOLINT(readability-magic-numbers)

--- a/libecole/tests/src/instance/test-capacitated-facility-location.cpp
+++ b/libecole/tests/src/instance/test-capacitated-facility-location.cpp
@@ -80,11 +80,6 @@ TEST_CASE("Instances generated are capacitated facility location instances", "[i
 				REQUIRE(scip::cons_get_lhs(scip_ptr, cons).value() == -inf);
 				REQUIRE(scip::cons_get_rhs(scip_ptr, cons).value() == 0.0);
 				REQUIRE(coefs.size() == params.n_customers + 1);
-			} else if (is_thightening(cons)) {
-				REQUIRE(scip::cons_get_lhs(scip_ptr, cons).value() == -inf);
-				REQUIRE(scip::cons_get_rhs(scip_ptr, cons).value() == 0.0);
-				REQUIRE(coefs.size() == 2);
-				REQUIRE(std::all_of(coefs.begin(), coefs.end(), [](auto coef) { return std::abs(coef) == 1.; }));
 			}
 		}
 	}

--- a/libecole/tests/src/instance/test-capacitated-facility-location.cpp
+++ b/libecole/tests/src/instance/test-capacitated-facility-location.cpp
@@ -65,7 +65,7 @@ TEST_CASE("Instances generated are capacitated facility location instances", "[i
 		// Correct number of constraints
 		REQUIRE(count_if(conss, is_demand) == params.n_customers);
 		REQUIRE(count_if(conss, is_capacity) == params.n_facilities);
-		REQUIRE(count_if(conss, is_thightening) == params.n_facilities * params.n_customers);
+		REQUIRE(count_if(conss, is_thightening) == params.n_facilities * params.n_customers + 1);
 
 		// Correct constraints bounds
 		auto const inf = SCIPinfinity(scip_ptr);


### PR DESCRIPTION
Three fixes:
1. the generator was imposing discrete servings by default (continuous_assignment = false);
2. instances were missing a global tightening constraint: the total demand must be satisfied;
3. the capacities were taking non-integer values, due to the scaling.

It looks like 1. was what was making the generated instances so difficult.

Addresses issue #141