### PR TITLE
Extract reward before observation

### DIFF
--- a/python/src/ecole/environment.py
+++ b/python/src/ecole/environment.py
@@ -43,10 +43,10 @@ class Environment:
 
         """
 
+        self.reward_function = ecole.data.parse(reward_function, self.__DefaultRewardFunction__())
         self.observation_function = ecole.data.parse(
             observation_function, self.__DefaultObservationFunction__()
         )
-        self.reward_function = ecole.data.parse(reward_function, self.__DefaultRewardFunction__())
         self.information_function = ecole.data.parse(
             information_function, self.__DefaultInformationFunction__()
         )
@@ -109,15 +109,15 @@ class Environment:
 
             self.dynamics.set_dynamics_random_state(self.model, self.random_engine)
 
-            self.observation_function.before_reset(self.model)
             self.reward_function.before_reset(self.model)
+            self.observation_function.before_reset(self.model)
             self.information_function.before_reset(self.model)
             done, action_set = self.dynamics.reset_dynamics(
                 self.model, *dynamics_args, **dynamics_kwargs
             )
 
-            observation = self.observation_function.extract(self.model, done)
             reward_offset = self.reward_function.extract(self.model, done)
+            observation = self.observation_function.extract(self.model, done)
             information = self.information_function.extract(self.model, done)
             return observation, action_set, reward_offset, done, information
         except Exception as e:
@@ -170,8 +170,8 @@ class Environment:
             done, action_set = self.dynamics.step_dynamics(
                 self.model, action, *dynamics_args, **dynamics_kwargs
             )
-            observation = self.observation_function.extract(self.model, done)
             reward = self.reward_function.extract(self.model, done)
+            observation = self.observation_function.extract(self.model, done)
             information = self.information_function.extract(self.model, done)
             return observation, action_set, reward, done, information
         except Exception as e:


### PR DESCRIPTION
In-between two environment steps, the following happens:
 - features are computed (observation function code)
 - an action is taken (user code)

From the perspective of an agent, if it can control the observation computation process as well as the action decision process, then those two operations can actually be fused into one, where the observation function directly returns the action which is to be taken.

Consider the following scenario: I use a configuring environment with the solving time as a reward. I want to discard the initial reward, as I do not want to account for the time it takes to load the instance file into SCIP. With the code as it is now, this will also discard the time it takes to compute the initial observation. As such, if I drop the initial reward, smart users might move all the computations required to evaluate their policy into the observation function, which will not be accounted for in the final reward.

The two operations (oi, ai) should be accounted for jointly in-between two environment steps. For example, think of the configuring environment. Previously the time was measured as follows:
 - t0
 - the environment transitions to s0
 - observation o0 is computed
 - t1
 - reward r0=(t1-t0) is returned, accounts for s0 and o0
 - action a0 is taken
 - the environment transitions to s1
 - observation o1 is computed
 - t2
 - reward r1=(t2-t1) is returned, accounts for a0, s1 and o1

It makes more sense, for credit assignment, to account for the time it takes to compute an observation and take a decision with respect to that observation within the same time period:
  - t0
 - the environment transitions to s0
 - t1
 - reward r0=(t1-t0) is returned, accounts for s0
 - observation o0 is computed
 - action a0 is taken
 - the environment transitions to s1
 - t2
 - reward r1=(t2-t1) is returned, accounts for o0, a0 and s1
 - observation o1 is computed