### PR TITLE
Remove LP notions (cols/rows) from observations

### DIFF
--- a/libecole/include/ecole/observation/nodebipartite.hpp
+++ b/libecole/include/ecole/observation/nodebipartite.hpp
@@ -12,10 +12,10 @@ namespace ecole::observation {
 struct NodeBipartiteObs {
 	using value_type = double;
 
-	static inline std::size_t constexpr n_static_column_features = 5;
-	static inline std::size_t constexpr n_dynamic_column_features = 14;
-	static inline std::size_t constexpr n_column_features = n_static_column_features + n_dynamic_column_features;
-	enum struct ColumnFeatures : std::size_t {
+	static inline std::size_t constexpr n_static_variable_features = 5;
+	static inline std::size_t constexpr n_dynamic_variable_features = 14;
+	static inline std::size_t constexpr n_variable_features = n_static_variable_features + n_dynamic_variable_features;
+	enum struct VariableFeatures : std::size_t {
 		/** Static features */
 		objective = 0,
 		is_type_binary,            // One hot encoded
@@ -54,7 +54,7 @@ struct NodeBipartiteObs {
 		scaled_age,
 	};
 
-	xt::xtensor<value_type, 2> column_features;
+	xt::xtensor<value_type, 2> variable_features;
 	xt::xtensor<value_type, 2> row_features;
 	utility::coo_matrix<value_type> edge_features;
 };

--- a/libecole/include/ecole/tweak/range.hpp
+++ b/libecole/include/ecole/tweak/range.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <utility>
+
+#include <nonstd/span.hpp>
+#include <range/v3/range_fwd.hpp>
+
+/**
+ * Tell the range library that `nonstd::span` is a view type.
+ *
+ * See `Rvalue Ranges and Views in C++20 <https://tristanbrindle.com/posts/rvalue-ranges-and-views>`_
+ * FIXME no longer needed when switching to C++20 ``std::span``.
+ * */
+namespace ranges {
+template <typename T, std::size_t Extent> inline constexpr bool enable_borrowed_range<nonstd::span<T, Extent>> = true;
+}  // namespace ranges

--- a/libecole/src/observation/khalil-2016.cpp
+++ b/libecole/src/observation/khalil-2016.cpp
@@ -551,15 +551,10 @@ void set_dynamic_features(
  * The static features have been computed for all LP columns and stored in the order of `LPcolumns`.
  * We need to find the one associated with the given variable.
  */
-template <typename Tensor>
-void set_precomputed_static_features(
-	Tensor&& out,
-	SCIP_VAR* const var,
-	xt::xtensor<value_type, 2> const& static_features) {
-
-	auto const col_idx = static_cast<std::ptrdiff_t>(SCIPcolGetIndex(SCIPvarGetCol(var)));
+template <typename TensorOut, typename TensorIn>
+void set_precomputed_static_features(TensorOut&& var_features, TensorIn const& var_static_features) {
 	using namespace xt::placeholders;
-	xt::view(out, xt::range(_, Khalil2016Obs::n_static_features)) = xt::row(static_features, col_idx);
+	xt::view(var_features, xt::range(_, Khalil2016Obs::n_static_features)) = var_static_features;
 }
 
 /******************************
@@ -568,20 +563,19 @@ void set_precomputed_static_features(
 
 auto extract_all_features(scip::Model& model, xt::xtensor<value_type, 2> const& static_features) {
 	xt::xtensor<value_type, 2> observation{
-		{model.pseudo_branch_cands().size(), Khalil2016Obs::n_features},
+		{model.variables().size(), Khalil2016Obs::n_features},
 		std::nan(""),
 	};
 
 	auto* const scip = model.get_scip_ptr();
 	auto const active_rows_weights = stats_for_active_constraint_coefficients_weights(model);
 
-	auto const pseudo_branch_cands = model.pseudo_branch_cands();
-	auto const n_pseudo_branch_cands = pseudo_branch_cands.size();
-	for (std::size_t var_idx = 0; var_idx < n_pseudo_branch_cands; ++var_idx) {
-		auto* const var = pseudo_branch_cands[var_idx];
-		auto features = xt::row(observation, static_cast<std::ptrdiff_t>(var_idx));
-		set_precomputed_static_features(features, var, static_features);
-		set_dynamic_features(features, scip, var, active_rows_weights);
+	for (auto* var : model.pseudo_branch_cands()) {
+		auto const var_idx = SCIPvarGetProbindex(var);
+		auto var_features = xt::row(observation, var_idx);
+		auto var_static_features = xt::row(static_features, var_idx);
+		set_precomputed_static_features(var_features, var_static_features);
+		set_dynamic_features(var_features, scip, var, active_rows_weights);
 	}
 
 	return observation;

--- a/libecole/src/observation/pseudocosts.cpp
+++ b/libecole/src/observation/pseudocosts.cpp
@@ -39,13 +39,13 @@ std::optional<xt::xtensor<double, 1>> Pseudocosts::extract(scip::Model& model, b
 	auto const [cands, lp_values] = scip_get_lp_branch_cands(scip);
 
 	/* Store pseudocosts in tensor */
-	auto const nb_lp_columns = static_cast<std::size_t>(SCIPgetNLPCols(scip));
-	xt::xtensor<double, 1> pseudocosts({nb_lp_columns}, std::nan(""));
+	auto const nb_vars = static_cast<std::size_t>(SCIPgetNVars(scip));
+	xt::xtensor<double, 1> pseudocosts({nb_vars}, std::nan(""));
 
 	for (auto const [var, lp_val] : views::zip(cands, lp_values)) {
-		auto const lp_index = static_cast<std::size_t>(SCIPcolGetLPPos(SCIPvarGetCol(var)));
+		auto const var_index = static_cast<std::size_t>(SCIPvarGetProbindex(var));
 		auto const score = SCIPgetVarPseudocostScore(scip, var, lp_val);
-		pseudocosts[lp_index] = static_cast<double>(score);
+		pseudocosts[var_index] = static_cast<double>(score);
 	}
 
 	return pseudocosts;

--- a/libecole/src/observation/strongbranchingscores.cpp
+++ b/libecole/src/observation/strongbranchingscores.cpp
@@ -68,12 +68,12 @@ std::optional<xt::xtensor<double, 1>> StrongBranchingScores::extract(scip::Model
 	model.set_param("branching/vanillafullstrong/idempotent", idempotent);
 
 	/* Store strong branching scores in tensor */
-	auto const num_lp_columns = static_cast<std::size_t>(SCIPgetNLPCols(scip));
-	auto strong_branching_scores = xt::xtensor<double, 1>({num_lp_columns}, std::nan(""));
+	auto const nb_vars = static_cast<std::size_t>(SCIPgetNVars(scip));
+	auto strong_branching_scores = xt::xtensor<double, 1>({nb_vars}, std::nan(""));
 
 	for (auto const [var, score] : views::zip(cands, cands_scores)) {
-		auto const lp_index = static_cast<std::size_t>(SCIPcolGetLPPos(SCIPvarGetCol(var)));
-		strong_branching_scores[lp_index] = static_cast<double>(score);
+		auto const var_index = static_cast<std::size_t>(SCIPvarGetProbindex(var));
+		strong_branching_scores[var_index] = static_cast<double>(score);
 	}
 
 	return strong_branching_scores;

--- a/libecole/tests/src/observation/test-khalil-2016.cpp
+++ b/libecole/tests/src/observation/test-khalil-2016.cpp
@@ -61,11 +61,8 @@ TEST_CASE("Khalil2016 return correct observation", "[obs]") {
 		auto col = [&obs_pseudo](auto feat) { return xt::col(obs_pseudo, static_cast<std::ptrdiff_t>(feat)); };
 
 		SECTION("No pseudo_candidate features are NaN or infinite") {
-			for (auto* var : model.pseudo_branch_cands()) {
-				auto const var_idx = SCIPvarGetProbindex(var);
-				REQUIRE_FALSE(xt::any(xt::isnan(xt::row(obs.features, var_idx))));
-				REQUIRE_FALSE(xt::any(xt::isinf(xt::row(obs.features, var_idx))));
-			}
+			REQUIRE_FALSE(xt::any(xt::isnan(obs_pseudo)));
+			REQUIRE_FALSE(xt::any(xt::isinf(obs_pseudo)));
 		}
 
 		SECTION("Objective function coefficients") {

--- a/libecole/tests/src/observation/test-khalil-2016.cpp
+++ b/libecole/tests/src/observation/test-khalil-2016.cpp
@@ -1,11 +1,19 @@
 #include <catch2/catch.hpp>
+#include <range/v3/view/enumerate.hpp>
+#include <range/v3/view/transform.hpp>
+#include <scip/scip.h>
+#include <xtensor/xindex_view.hpp>
 #include <xtensor/xmath.hpp>
+#include <xtensor/xtensor.hpp>
 #include <xtensor/xview.hpp>
 
 #include "ecole/observation/khalil-2016.hpp"
+#include "ecole/tweak/range.hpp"
 
 #include "conftest.hpp"
 #include "observation/unit-tests.hpp"
+
+namespace views = ranges::views;
 
 using namespace ecole;
 
@@ -17,6 +25,16 @@ template <typename Tensor, typename T = typename Tensor::value_type>
 auto in_interval(Tensor const& tensor, T const& lower, T const& upper) {
 	// Must take bounds by reference because they are captured by reference in the xexpression
 	return (lower <= tensor) && (tensor <= upper);
+}
+
+/** Get the features of the pseudo candidate only. */
+template <typename Tensor, typename Range>
+auto obs_pseudo_cands(Tensor const& obs_features, Range const& pseudo_cands_idx) -> Tensor {
+	auto filtered_features = Tensor::from_shape({pseudo_cands_idx.size(), obs_features.shape()[1]});
+	for (auto const [idx, var_idx] : views::enumerate(pseudo_cands_idx)) {
+		xt::row(filtered_features, static_cast<std::ptrdiff_t>(idx)) = xt::row(obs_features, var_idx);
+	}
+	return filtered_features;
 }
 
 TEST_CASE("Khalil2016 return correct observation", "[obs]") {
@@ -32,19 +50,23 @@ TEST_CASE("Khalil2016 return correct observation", "[obs]") {
 
 	SECTION("Observation features has correct shape") {
 		auto const& obs = optional_obs.value();
-		REQUIRE(obs.features.shape(0) == model.pseudo_branch_cands().size());
+		REQUIRE(obs.features.shape(0) == model.variables().size());
 		REQUIRE(obs.features.shape(1) == observation::Khalil2016Obs::n_features);
-	}
-
-	SECTION("No features are NaN or infinite") {
-		auto const& obs = optional_obs.value();
-		REQUIRE_FALSE(xt::any(xt::isnan(obs.features)));
-		REQUIRE_FALSE(xt::any(xt::isinf(obs.features)));
 	}
 
 	SECTION("Observation has correct values") {
 		auto const& obs = optional_obs.value();
-		auto col = [&obs](auto feat) { return xt::col(obs.features, static_cast<std::ptrdiff_t>(feat)); };
+		auto obs_pseudo =
+			obs_pseudo_cands(obs.features, views::transform(model.pseudo_branch_cands(), SCIPvarGetProbindex));
+		auto col = [&obs_pseudo](auto feat) { return xt::col(obs_pseudo, static_cast<std::ptrdiff_t>(feat)); };
+
+		SECTION("No pseudo_candidate features are NaN or infinite") {
+			for (auto* var : model.pseudo_branch_cands()) {
+				auto const var_idx = SCIPvarGetProbindex(var);
+				REQUIRE_FALSE(xt::any(xt::isnan(xt::row(obs.features, var_idx))));
+				REQUIRE_FALSE(xt::any(xt::isinf(xt::row(obs.features, var_idx))));
+			}
+		}
 
 		SECTION("Objective function coefficients") {
 			REQUIRE(xt::all(col(Features::obj_coef_pos_part) >= 0));

--- a/libecole/tests/src/observation/test-nodebipartite.cpp
+++ b/libecole/tests/src/observation/test-nodebipartite.cpp
@@ -30,7 +30,7 @@ TEST_CASE("NodeBipartite return correct observation", "[obs]") {
 
 	SECTION("Observation features are not empty") {
 		auto const& obs = optional_obs.value();
-		REQUIRE(obs.column_features.size() > 0);
+		REQUIRE(obs.variable_features.size() > 0);
 		REQUIRE(obs.row_features.size() > 0);
 		REQUIRE(obs.edge_features.nnz() > 0);
 	}
@@ -38,22 +38,22 @@ TEST_CASE("NodeBipartite return correct observation", "[obs]") {
 	SECTION("Observation features have matching shape") {
 		auto const& obs = optional_obs.value();
 		REQUIRE(obs.row_features.shape()[0] == obs.edge_features.shape[0]);
-		REQUIRE(obs.column_features.shape()[0] == obs.edge_features.shape[1]);
+		REQUIRE(obs.variable_features.shape()[0] == obs.edge_features.shape[1]);
 		REQUIRE(obs.edge_features.indices.shape()[0] == 2);
 		REQUIRE(obs.edge_features.indices.shape()[1] == obs.edge_features.nnz());
 	}
 
-	SECTION("Columns features are not all nan") {
-		auto const& col_feat = optional_obs.value().column_features;
-		for (std::size_t i = 0; i < col_feat.shape()[1]; ++i) {
-			REQUIRE_FALSE(xt::all(xt::isnan(xt::col(col_feat, static_cast<std::ptrdiff_t>(i)))));
+	SECTION("Variable features are not all nan") {
+		auto const& var_feat = optional_obs.value().variable_features;
+		for (std::size_t i = 0; i < var_feat.shape()[1]; ++i) {
+			REQUIRE_FALSE(xt::all(xt::isnan(xt::col(var_feat, static_cast<std::ptrdiff_t>(i)))));
 		}
 	}
 
 	SECTION("Row features are not all nan") {
 		auto const& row_feat = optional_obs.value().row_features;
 		for (std::size_t i = 0; i < row_feat.shape()[1]; ++i) {
-			REQUIRE_FALSE(xt::all(xt::isnan(xt::row(row_feat, static_cast<std::ptrdiff_t>(i)))));
+			REQUIRE_FALSE(xt::all(xt::isnan(xt::col(row_feat, static_cast<std::ptrdiff_t>(i)))));
 		}
 	}
 }

--- a/libecole/tests/src/observation/test-nodebipartite.cpp
+++ b/libecole/tests/src/observation/test-nodebipartite.cpp
@@ -44,16 +44,12 @@ TEST_CASE("NodeBipartite return correct observation", "[obs]") {
 	}
 
 	SECTION("Variable features are not all nan") {
-		auto const& var_feat = optional_obs.value().variable_features;
-		for (std::size_t i = 0; i < var_feat.shape()[1]; ++i) {
-			REQUIRE_FALSE(xt::all(xt::isnan(xt::col(var_feat, static_cast<std::ptrdiff_t>(i)))));
-		}
+		auto const& obs = optional_obs.value();
+		REQUIRE_FALSE(xt::all(xt::isnan(obs.variable_features)));
 	}
 
 	SECTION("Row features are not all nan") {
-		auto const& row_feat = optional_obs.value().row_features;
-		for (std::size_t i = 0; i < row_feat.shape()[1]; ++i) {
-			REQUIRE_FALSE(xt::all(xt::isnan(xt::col(row_feat, static_cast<std::ptrdiff_t>(i)))));
-		}
+		auto const& obs = optional_obs.value();
+		REQUIRE_FALSE(xt::all(xt::isnan(obs.row_features)));
 	}
 }

--- a/libecole/tests/src/observation/test-pseudocosts.cpp
+++ b/libecole/tests/src/observation/test-pseudocosts.cpp
@@ -23,12 +23,12 @@ TEST_CASE("Pseudocosts return pseudo costs array", "[obs]") {
 
 	REQUIRE(obs.has_value());
 	auto const& costs = obs.value();
-	REQUIRE(costs.size() == model.lp_columns().size());
+	REQUIRE(costs.size() == model.variables().size());
 
 	// All branching candidates have a positive pseudocost
 	for (auto* const var : model.lp_branch_cands()) {
-		auto const lp_index = static_cast<std::size_t>(SCIPcolGetLPPos(SCIPvarGetCol(var)));
-		auto const pseudocost = costs[lp_index];
+		auto const var_index = static_cast<std::size_t>(SCIPvarGetProbindex(var));
+		auto const pseudocost = costs[var_index];
 		REQUIRE(!std::isnan(pseudocost));
 		REQUIRE(pseudocost > 0);
 	}

--- a/python/src/ecole/core/observation.cpp
+++ b/python/src/ecole/core/observation.cpp
@@ -85,7 +85,7 @@ void bind_submodule(py::module_ const& m) {
 
 		The optimization problem is represented as an heterogenous bipartite graph.
 		On one side, a node is associated with one variable, on the other side a node is
-		associated with one constraint.
+		associated with one LP row.
 		There exist an edge between a variable and a constraint if the variable exists in the
 		constraint with a non-zero coefficient.
 
@@ -236,13 +236,13 @@ void bind_submodule(py::module_ const& m) {
 		Strong branching score observation function on branch-and bound node.
 
 		This observation obtains scores for all LP or pseudo candidate variables at a
-		branch-and-bound node.  The strong branching score measures the quality of branching
-		for each variable.  This observation can be used as an expert for imitation
-		learning algorithms.
+		branch-and-bound node.
+		The strong branching score measures the quality of branching for each variable.
+		This observation can be used as an expert for imitation learning algorithms.
 
 		This observation function extracts an array containing the strong branching score for
-		each variable in the problem which can be indexed by the action set.  Variables for which
-		a strong branching score is not applicable are filled with NaN.
+		each variable in the problem which can be indexed by the action set.
+		Variables for which a strong branching score is not applicable are filled with ``NaN``.
 	)");
 	strong_branching_scores.def(py::init<bool>(), py::arg("pseudo_candidates") = true, R"(
 		Constructor for StrongBranchingScores.
@@ -269,8 +269,8 @@ void bind_submodule(py::module_ const& m) {
 		pseudocost branching (also known as hybrid branching).
 
 		This observation function extracts an array containing the pseudocost for
-		each variable in the problem which can be indexed by the action set.  Variables for which
-		a pseudocost is not applicable are filled with NaN.
+		each variable in the problem which can be indexed by the action set.
+		Variables for which a pseudocost is not applicable are filled with ``NaN``.
 	)");
 	pseudocosts.def(py::init<>());
 	def_before_reset(pseudocosts, R"(Do nothing.)");
@@ -283,8 +283,8 @@ void bind_submodule(py::module_ const& m) {
 
 		The observation is a matrix where rows represent all variables and columns represent features related
 		to these variables.
-		Only rows representing pseudo branching candidate contain meaningful observation, other rows are filled with
-		``NaN``.
+		Only rows representing pseudo branching candidate contain meaningful observation, other rows are filled
+		with ``NaN``.
 		See [Khalil2016]_ for a complete reference on this observation function.
 
 		The first :py:attr:`Khalil2016Obs.n_static_features` are static (they do not change through the solving

--- a/python/src/ecole/core/observation.cpp
+++ b/python/src/ecole/core/observation.cpp
@@ -93,10 +93,10 @@ void bind_submodule(py::module_ const& m) {
 		Each edge is associated with the coefficient of the variable in the constraint.
 	)")
 			.def_auto_copy()
-			.def_auto_pickle(std::array{"column_features", "row_features", "edge_features"})
+			.def_auto_pickle(std::array{"variable_features", "row_features", "edge_features"})
 			.def_readwrite_xtensor(
-				"column_features",
-				&NodeBipartiteObs::column_features,
+				"variable_features",
+				&NodeBipartiteObs::variable_features,
 				"A matrix where each row is represents a variable, and each column a feature of the variables.")
 			.def_readwrite_xtensor(
 				"row_features",
@@ -108,26 +108,26 @@ void bind_submodule(py::module_ const& m) {
 				"The constraint matrix of the optimization problem, with rows for contraints and "
 				"columns for variables.");
 
-	py::enum_<NodeBipartiteObs::ColumnFeatures>(node_bipartite_obs, "ColumnFeatures")
-		.value("objective", NodeBipartiteObs::ColumnFeatures::objective)
-		.value("is_type_binary", NodeBipartiteObs::ColumnFeatures::is_type_binary)
-		.value("is_type_integer", NodeBipartiteObs::ColumnFeatures::is_type_integer)
-		.value("is_type_implicit_integer", NodeBipartiteObs::ColumnFeatures::is_type_implicit_integer)
-		.value("is_type_continuous", NodeBipartiteObs::ColumnFeatures::is_type_continuous)
-		.value("has_lower_bound", NodeBipartiteObs::ColumnFeatures::has_lower_bound)
-		.value("has_upper_bound", NodeBipartiteObs::ColumnFeatures::has_upper_bound)
-		.value("normed_reduced_cost", NodeBipartiteObs::ColumnFeatures::normed_reduced_cost)
-		.value("solution_value", NodeBipartiteObs::ColumnFeatures::solution_value)
-		.value("solution_frac", NodeBipartiteObs::ColumnFeatures::solution_frac)
-		.value("is_solution_at_lower_bound", NodeBipartiteObs::ColumnFeatures::is_solution_at_lower_bound)
-		.value("is_solution_at_upper_bound", NodeBipartiteObs::ColumnFeatures::is_solution_at_upper_bound)
-		.value("scaled_age", NodeBipartiteObs::ColumnFeatures::scaled_age)
-		.value("incumbent_value", NodeBipartiteObs::ColumnFeatures::incumbent_value)
-		.value("average_incumbent_value", NodeBipartiteObs::ColumnFeatures::average_incumbent_value)
-		.value("is_basis_lower", NodeBipartiteObs::ColumnFeatures::is_basis_lower)
-		.value("is_basis_basic", NodeBipartiteObs::ColumnFeatures::is_basis_basic)
-		.value("is_basis_upper", NodeBipartiteObs::ColumnFeatures::is_basis_upper)
-		.value("is_basis_zero", NodeBipartiteObs::ColumnFeatures ::is_basis_zero);
+	py::enum_<NodeBipartiteObs::VariableFeatures>(node_bipartite_obs, "VariableFeatures")
+		.value("objective", NodeBipartiteObs::VariableFeatures::objective)
+		.value("is_type_binary", NodeBipartiteObs::VariableFeatures::is_type_binary)
+		.value("is_type_integer", NodeBipartiteObs::VariableFeatures::is_type_integer)
+		.value("is_type_implicit_integer", NodeBipartiteObs::VariableFeatures::is_type_implicit_integer)
+		.value("is_type_continuous", NodeBipartiteObs::VariableFeatures::is_type_continuous)
+		.value("has_lower_bound", NodeBipartiteObs::VariableFeatures::has_lower_bound)
+		.value("has_upper_bound", NodeBipartiteObs::VariableFeatures::has_upper_bound)
+		.value("normed_reduced_cost", NodeBipartiteObs::VariableFeatures::normed_reduced_cost)
+		.value("solution_value", NodeBipartiteObs::VariableFeatures::solution_value)
+		.value("solution_frac", NodeBipartiteObs::VariableFeatures::solution_frac)
+		.value("is_solution_at_lower_bound", NodeBipartiteObs::VariableFeatures::is_solution_at_lower_bound)
+		.value("is_solution_at_upper_bound", NodeBipartiteObs::VariableFeatures::is_solution_at_upper_bound)
+		.value("scaled_age", NodeBipartiteObs::VariableFeatures::scaled_age)
+		.value("incumbent_value", NodeBipartiteObs::VariableFeatures::incumbent_value)
+		.value("average_incumbent_value", NodeBipartiteObs::VariableFeatures::average_incumbent_value)
+		.value("is_basis_lower", NodeBipartiteObs::VariableFeatures::is_basis_lower)
+		.value("is_basis_basic", NodeBipartiteObs::VariableFeatures::is_basis_basic)
+		.value("is_basis_upper", NodeBipartiteObs::VariableFeatures::is_basis_upper)
+		.value("is_basis_zero", NodeBipartiteObs::VariableFeatures ::is_basis_zero);
 
 	py::enum_<NodeBipartiteObs::RowFeatures>(node_bipartite_obs, "RowFeatures")
 		.value("bias", NodeBipartiteObs::RowFeatures::bias)

--- a/python/src/ecole/core/observation.cpp
+++ b/python/src/ecole/core/observation.cpp
@@ -102,6 +102,18 @@ void bind_submodule(py::module_ const& m) {
 				"row_features",
 				&NodeBipartiteObs::row_features,
 				"A matrix where each row is represents a constraint, and each column a feature of the constraints.")
+			// FIXME remove in version >0.8
+			.def_property(
+				"column_features",
+				[](py::handle self) {
+					PyErr_WarnEx(PyExc_DeprecationWarning, "column_features is deprecated, use variable_features.", 1);
+					return self.attr("variable_features");
+				},
+				[](py::handle self, py::handle const val) {
+					PyErr_WarnEx(PyExc_DeprecationWarning, "column_features is deprecated, use variable_features.", 1);
+					self.attr("variable_features") = val;
+				},
+				"A matrix where each row is represents a variable, and each column a feature of the variables.")
 			.def_readwrite(
 				"edge_features",
 				&NodeBipartiteObs::edge_features,
@@ -128,6 +140,12 @@ void bind_submodule(py::module_ const& m) {
 		.value("is_basis_basic", NodeBipartiteObs::VariableFeatures::is_basis_basic)
 		.value("is_basis_upper", NodeBipartiteObs::VariableFeatures::is_basis_upper)
 		.value("is_basis_zero", NodeBipartiteObs::VariableFeatures ::is_basis_zero);
+
+	// FIXME remove in Ecole >0.8
+	node_bipartite_obs.def_property_readonly_static("ColumnFeatures", [](py::handle self) {
+		PyErr_WarnEx(PyExc_DeprecationWarning, "ColumnFeatures is deprecated, use VariableFeatures.", 1);
+		return self.attr("VariableFeatures");
+	});
 
 	py::enum_<NodeBipartiteObs::RowFeatures>(node_bipartite_obs, "RowFeatures")
 		.value("bias", NodeBipartiteObs::RowFeatures::bias)

--- a/python/src/ecole/core/observation.cpp
+++ b/python/src/ecole/core/observation.cpp
@@ -263,8 +263,10 @@ void bind_submodule(py::module_ const& m) {
 		auto_class<Khalil2016Obs>(m, "Khalil2016Obs", R"(
 		Branching candidates features from Khalil et al. (2016).
 
-		The observation is a matrix where rows represent pseudo branching candidates and columns
-		represent features related to these variables.
+		The observation is a matrix where rows represent all variables and columns represent features related
+		to these variables.
+		Only rows representing pseudo branching candidate contain meaningful observation, other rows are filled with
+		``NaN``.
 		See [Khalil2016]_ for a complete reference on this observation function.
 
 		The first :py:attr:`Khalil2016Obs.n_static_features` are static (they do not change through the solving

--- a/python/tests/test_observation.py
+++ b/python/tests/test_observation.py
@@ -87,6 +87,8 @@ def test_Nothing_observation(model):
     assert make_obs(ecole.observation.Nothing(), model) is None
 
 
+# FIXME remove in Ecole >0.8
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_NodeBipartite_observation(model):
     """Observation of NodeBipartite is a type with array attributes."""
     obs = make_obs(ecole.observation.NodeBipartite(), model)
@@ -99,6 +101,10 @@ def test_NodeBipartite_observation(model):
     # Check that there are enums describing feeatures
     assert len(obs.VariableFeatures.__members__) == obs.variable_features.shape[1]
     assert len(obs.RowFeatures.__members__) == obs.row_features.shape[1]
+
+    # FIXME remove in Ecole >0.8
+    assert_array(obs.column_features, ndim=2)
+    assert len(obs.ColumnFeatures.__members__) == obs.variable_features.shape[1]
 
 
 def test_MilpBipartite_observation(model):

--- a/python/tests/test_observation.py
+++ b/python/tests/test_observation.py
@@ -91,13 +91,13 @@ def test_NodeBipartite_observation(model):
     """Observation of NodeBipartite is a type with array attributes."""
     obs = make_obs(ecole.observation.NodeBipartite(), model)
     assert isinstance(obs, ecole.observation.NodeBipartiteObs)
-    assert_array(obs.column_features, ndim=2)
+    assert_array(obs.variable_features, ndim=2)
     assert_array(obs.row_features, ndim=2)
     assert_array(obs.edge_features.values)
     assert_array(obs.edge_features.indices, ndim=2, dtype=np.uint64)
 
     # Check that there are enums describing feeatures
-    assert len(obs.ColumnFeatures.__members__) == obs.column_features.shape[1]
+    assert len(obs.VariableFeatures.__members__) == obs.variable_features.shape[1]
     assert len(obs.RowFeatures.__members__) == obs.row_features.shape[1]
 
 


### PR DESCRIPTION
Like the title says.
Fixes #200 .

For all observation functions that iterate over variables, **all** variables should be iterated in the order of `Model::variables` (possibly leaving unwanted variables with `nan`).

### Observations:
 - [x] Node Bipartite
   - [x] Rename `col_features` > `var_features`
   - [x] Keep `col_features` alias with Deprecation Warning
 - [x] Milp Bipartite
 - [x] Strong Branching Scores
 - [x] Pseudo costs
 - [x] Khalil
 - [x] Hutter (nothing to do)
 
 ### Dynamics:
  - [x] Branching Dynamics