### PR TITLE
Prevent solving interrupts during state extraction

### DIFF
--- a/libecole/include/ecole/environment/environment.hpp
+++ b/libecole/include/ecole/environment/environment.hpp
@@ -118,17 +118,21 @@ public:
 			auto const [done, action_set] = dynamics().reset_dynamics(model(), std::forward<Args>(args)...);
 			can_transition = !done;
 
+			auto limit_values = model().pause_limits();
 			auto observation = OptionalObservation{};
 			if (!done) {
 				observation = observation_function().extract(model(), done);
 			}
-			return {
+			std::tuple<Observation, ActionSet, Reward, bool, InformationMap> transition_data = {
 				std::move(observation),
+				observation_function().extract(model(), done),
 				std::move(action_set),
 				reward_function().extract(model(), done),
 				done,
 				information_function().extract(model(), done),
 			};
+			model().set_params(limit_values);
+			return transition_data;
 		} catch (std::exception const&) {
 			can_transition = false;
 			throw;
@@ -173,17 +177,20 @@ public:
 			auto const [done, action_set] = dynamics().step_dynamics(model(), action, std::forward<Args>(args)...);
 			can_transition = !done;
 
+			auto limit_values = model().pause_limits();
 			auto observation = OptionalObservation{};
 			if (!done) {
 				observation = observation_function().extract(model(), done);
 			}
-			return {
+			std::tuple<Observation, ActionSet, Reward, bool, InformationMap> transition_data = {
 				std::move(observation),
 				std::move(action_set),
 				reward_function().extract(model(), done),
 				done,
 				information_function().extract(model(), done),
 			};
+			model().set_params(limit_values);
+			return transition_data;
 		} catch (std::exception const&) {
 			can_transition = false;
 			throw;

--- a/libecole/include/ecole/scip/model.hpp
+++ b/libecole/include/ecole/scip/model.hpp
@@ -100,6 +100,7 @@ public:
 	 */
 	template <ParamType T> void set_param(std::string const& name, utility::value_or_const_ref_t<param_t<T>> value);
 	template <ParamType T> [[nodiscard]] param_t<T> get_param(std::string const& name) const;
+	template <ParamType T> [[nodiscard]] param_t<T> get_param_default(std::string const& name) const;
 
 	/**
 	 * Get and set parameters with automatic casting.
@@ -110,9 +111,11 @@ public:
 	 */
 	template <typename T> void set_param(std::string const& name, T value);
 	template <typename T> [[nodiscard]] T get_param(std::string const& name) const;
+	template <typename T> [[nodiscard]] T get_param_default(std::string const& name) const;
 
 	void set_params(std::map<std::string, Param> name_values);
 	[[nodiscard]] std::map<std::string, Param> get_params() const;
+	std::map<std::string, Param> pause_limits();
 
 	void disable_presolve();
 	void disable_cuts();
@@ -234,6 +237,28 @@ template <typename T> T Model::get_param(std::string const& name) const {
 		return cast<T>(get_param<ParamType::Char>(name));
 	case ParamType::String:
 		return cast<T>(get_param<ParamType::String>(name));
+	default:
+		assert(false);  // All enum value should be handled
+		// Non void return for optimized build
+		throw Exception("Could not find type for given parameter");
+	}
+}
+
+template <typename T> T Model::get_param_default(std::string const& name) const {
+	using namespace internal;
+	switch (get_param_type(name)) {
+	case ParamType::Bool:
+		return cast<T>(get_param_default<ParamType::Bool>(name));
+	case ParamType::Int:
+		return cast<T>(get_param_default<ParamType::Int>(name));
+	case ParamType::LongInt:
+		return cast<T>(get_param_default<ParamType::LongInt>(name));
+	case ParamType::Real:
+		return cast<T>(get_param_default<ParamType::Real>(name));
+	case ParamType::Char:
+		return cast<T>(get_param_default<ParamType::Char>(name));
+	case ParamType::String:
+		return cast<T>(get_param_default<ParamType::String>(name));
 	default:
 		assert(false);  // All enum value should be handled
 		// Non void return for optimized build

--- a/libecole/src/scip/model.cpp
+++ b/libecole/src/scip/model.cpp
@@ -160,6 +160,37 @@ template <> std::string Model::get_param<ParamType::String>(std::string const& n
 	return ptr;
 }
 
+template <> bool Model::get_param_default<ParamType::Bool>(std::string const& name) const {
+	auto* param = SCIPgetParam(const_cast<SCIP*>(get_scip_ptr()), name.c_str());
+	SCIP_Bool default_value = SCIPparamGetBoolDefault(param);
+	return static_cast<bool>(default_value);
+}
+template <> int Model::get_param_default<ParamType::Int>(std::string const& name) const {
+	auto* param = SCIPgetParam(const_cast<SCIP*>(get_scip_ptr()), name.c_str());
+	int default_value = SCIPparamGetIntDefault(param);
+	return default_value;
+}
+template <> SCIP_Longint Model::get_param_default<ParamType::LongInt>(std::string const& name) const {
+	auto* param = SCIPgetParam(const_cast<SCIP*>(get_scip_ptr()), name.c_str());
+	SCIP_Longint default_value = SCIPparamGetLongintDefault(param);
+	return default_value;
+}
+template <> SCIP_Real Model::get_param_default<ParamType::Real>(std::string const& name) const {
+	auto* param = SCIPgetParam(const_cast<SCIP*>(get_scip_ptr()), name.c_str());
+	SCIP_Real default_value = SCIPparamGetRealDefault(param);
+	return default_value;
+}
+template <> char Model::get_param_default<ParamType::Char>(std::string const& name) const {
+	auto* param = SCIPgetParam(const_cast<SCIP*>(get_scip_ptr()), name.c_str());
+	char default_value = SCIPparamGetCharDefault(param);
+	return default_value;
+}
+template <> std::string Model::get_param_default<ParamType::String>(std::string const& name) const {
+	auto* param = SCIPgetParam(const_cast<SCIP*>(get_scip_ptr()), name.c_str());
+	char* default_value = SCIPparamGetStringDefault(param);
+	return default_value;
+}
+
 void Model::set_params(std::map<std::string, Param> name_values) {
 	for (auto&& [name, value] : ranges::views::move(name_values)) {
 		set_param(name, std::move(value));
@@ -183,6 +214,30 @@ std::map<std::string, Param> Model::get_params() const {
 		name_values.insert({std::move(name), std::move(value)});
 	}
 	return name_values;
+}
+
+std::map<std::string, Param> Model::pause_limits() {
+	static auto constexpr names = std::array{
+		"limits/time",
+		"limits/nodes",
+		"limits/totalnodes",
+		"limits/stallnodes",
+		"limits/memory",
+		"limits/gap",
+		"limits/absgap",
+		"limits/solutions",
+		"limits/bestsol",
+		"limits/maxsol",
+		"limits/maxorigsol",
+		"limits/restarts",
+		"limits/autorestartnodes",
+	};
+	auto saved = std::map<std::string, Param>{};
+	for (auto const& name : names) {
+		saved[name] = get_param<Param>(name);
+		set_param(name, get_param_default<Param>(name));
+	}
+	return saved;
 }
 
 void Model::disable_presolve() {

--- a/python/src/ecole/core/scip.cpp
+++ b/python/src/ecole/core/scip.cpp
@@ -81,6 +81,7 @@ void bind_submodule(py::module_ const& m) {
 		.def("set_param", &Model::set_param<Param>, py::arg("name"), py::arg("value"))
 		.def("get_params", &Model::get_params)
 		.def("set_params", &Model::set_params, py::arg("name_values"))
+		.def("pause_limits", &Model::pause_limits)
 		.def("disable_cuts", &Model::disable_cuts)
 		.def("disable_presolve", &Model::disable_presolve)
 		.def(

--- a/python/src/ecole/environment.py
+++ b/python/src/ecole/environment.py
@@ -116,6 +116,8 @@ class Environment:
                 self.model, *dynamics_args, **dynamics_kwargs
             )
 
+            limit_values = self.model.pause_limits()
+
             if not done:
                 observation = self.observation_function.extract(self.model, done)
             else:
@@ -123,6 +125,8 @@ class Environment:
             reward_offset = self.reward_function.extract(self.model, done)
             observation = self.observation_function.extract(self.model, done)
             information = self.information_function.extract(self.model, done)
+
+            self.model.set_params(limit_values)
 
             return observation, action_set, reward_offset, done, information
         except Exception as e:
@@ -176,6 +180,8 @@ class Environment:
                 self.model, action, *dynamics_args, **dynamics_kwargs
             )
 
+            limit_values = self.model.pause_limits()
+
             if not done:
                 observation = self.observation_function.extract(self.model, done)
             else:
@@ -183,6 +189,8 @@ class Environment:
             reward = self.reward_function.extract(self.model, done)
             observation = self.observation_function.extract(self.model, done)
             information = self.information_function.extract(self.model, done)
+
+            self.model.set_params(limit_values)
 
             return observation, action_set, reward, done, information
         except Exception as e:


### PR DESCRIPTION
That is, make state extraction (observation/reward/info) atomic.