### PR TITLE
Release 0.7.2

### DIFF
--- a/libecole/CMakeLists.txt
+++ b/libecole/CMakeLists.txt
@@ -125,6 +125,7 @@ find_or_download_package(
 		-D FMT_DOC=OFF
 		-D FMT_INSTALL=ON
 		-D CMAKE_BUILD_TYPE=Release
+		-D BUILD_SHARED_LIBS=OFF
 		-D CMAKE_POSITION_INDEPENDENT_CODE=${CMAKE_POSITION_INDEPENDENT_CODE}
 )
 find_or_download_package(


### PR DESCRIPTION
I think we should release this new version quickly, to fix the current bug in 0.7.1 where observations are extracted twice.

Changes:
 - fmt is now built as a static library
 - reward / observation extraction is now made in the proper order in both the C++ and Python Environment class
 - bugfix: observations are not extracted twice any more in the Python Environment class