### PR TITLE
Fix doc nav bar color on mobile

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,7 +1,7 @@
 @import url("theme.css");
 
-/* Style the top search bar and logo */
-.wy-side-nav-search {
+/* Style the top search bar and logo, or top bar on mobile */
+.wy-side-nav-search, .wy-nav-top {
 	background-color: #F58A1F;
 }
 


### PR DESCRIPTION
On mobile, the top bar color was still the original blue instead of orange.
