### PR TITLE
Allow defaut SCIP in branching environment

### DIFF
--- a/libecole/include/ecole/dynamics/branching.hpp
+++ b/libecole/include/ecole/dynamics/branching.hpp
@@ -11,7 +11,7 @@
 namespace ecole::dynamics {
 
 class ECOLE_EXPORT BranchingDynamics :
-	public EnvironmentDynamics<std::size_t, std::optional<xt::xtensor<std::size_t, 1>>> {
+	public EnvironmentDynamics<std::optional<std::size_t>, std::optional<xt::xtensor<std::size_t, 1>>> {
 public:
 	using ActionSet = std::optional<xt::xtensor<std::size_t, 1>>;
 
@@ -19,7 +19,7 @@ public:
 
 	ECOLE_EXPORT auto reset_dynamics(scip::Model& model) -> std::tuple<bool, ActionSet> override;
 
-	ECOLE_EXPORT auto step_dynamics(scip::Model& model, std::size_t const& var_idx)
+	ECOLE_EXPORT auto step_dynamics(scip::Model& model, std::optional<std::size_t> const& maybe_var_idx)
 		-> std::tuple<bool, ActionSet> override;
 
 private:

--- a/libecole/src/dynamics/branching.cpp
+++ b/libecole/src/dynamics/branching.cpp
@@ -37,14 +37,23 @@ auto BranchingDynamics::reset_dynamics(scip::Model& model) -> std::tuple<bool, A
 	return {false, action_set(model, pseudo_candidates)};
 }
 
-auto BranchingDynamics::step_dynamics(scip::Model& model, std::size_t const& var_idx) -> std::tuple<bool, ActionSet> {
-	auto const vars = model.variables();
-	if (var_idx >= vars.size()) {
-		throw std::invalid_argument{
-			fmt::format("Branching candidate index {} larger than the number of variables ({}).", var_idx, vars.size())};
+auto BranchingDynamics::step_dynamics(scip::Model& model, std::optional<std::size_t> const& maybe_var_idx)
+	-> std::tuple<bool, ActionSet> {
+	if (maybe_var_idx.has_value()) {
+		auto const var_idx = maybe_var_idx.value();
+		auto const vars = model.variables();
+		// Error handling
+		if (var_idx >= vars.size()) {
+			throw std::invalid_argument{
+				fmt::format("Branching candidate index {} larger than the number of variables ({}).", var_idx, vars.size())};
+		}
+		// Branching
+		scip::call(SCIPbranchVar, model.get_scip_ptr(), vars[var_idx], nullptr, nullptr, nullptr);
+		model.solve_iter_branch(SCIP_BRANCHED);
+	} else {
+		// Fallback to SCIP default branching
+		model.solve_iter_branch(SCIP_DIDNOTRUN);
 	}
-	scip::call(SCIPbranchVar, model.get_scip_ptr(), vars[var_idx], nullptr, nullptr, nullptr);
-	model.solve_iter_branch(SCIP_BRANCHED);
 
 	if (model.solve_iter_is_done()) {
 		return {true, {}};

--- a/libecole/tests/src/dynamics/test-branching.cpp
+++ b/libecole/tests/src/dynamics/test-branching.cpp
@@ -55,6 +55,14 @@ TEST_CASE("BranchingDynamics functional tests", "[dynamics]") {
 		auto const action = model.lp_columns().size() + 1;
 		REQUIRE_THROWS_AS(dyn.step_dynamics(model, action), std::invalid_argument);
 	}
+
+	SECTION("Provides default branching") {
+		auto [done, _] = dyn.reset_dynamics(model);
+		while (!done) {
+			std::tie(done, _) = dyn.step_dynamics(model, {});
+		}
+		REQUIRE(model.is_solved());
+	}
 }
 
 TEST_CASE("BranchingDynamics handles limits", "[dynamics]") {

--- a/python/ecole/src/ecole/core/dynamics.cpp
+++ b/python/ecole/src/ecole/core/dynamics.cpp
@@ -102,6 +102,8 @@ void bind_submodule(pybind11::module_ const& m) {
 						The state of the Markov Decision Process. Passed by the environment.
 					action:
 						The index the LP column of the variable to branch on. One element of the action set.
+						If an explicity ``None`` is passed, then default SCIP branching is used, that is, the next
+						branching rule is used fetch by SCIP according to their priorities.
 
 				Returns
 				-------


### PR DESCRIPTION
The motivation is two folds:
-  Be able to benchmark with a control flow similar that the one used for branching, collecting intermediary information (also very useful for debugging);
- Train agents that can be uncertain and prefer SCIP policy. 

## Pull request checklist
<!---
Thank you for contributing to Ecole!

⚠️ To ensure a smooth review, please make sure to complete the following checklist. ⚠️

Except for very small fixes, please open an issue to discuss the changes and fill
the number bellow.
Refer to the documentation for help on running the tests, checks, formatters, and documentation.
-->
- [ ] I have opened an issue to discuss the proposed changes: Fix #XX.
- [x] I have modified/added tests to cover the new changes/features.
- [x] I have modified/added the documentation to cover the new changes/features.
- [x] I have ran the tests, checks, and code formatters.

## Proposed implementation
Default branching is performed by passing `None` as an action / branching variable to `env.step`.

Alternatively, I though one could give a token, like
```python
env.step(ecole.environment.default_action)
```
The advantage would be to avoid involuntary default branching (if users unknowingly get a `None` output in their policy).
